### PR TITLE
Introduce half-edge topology and update geometry pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(${PROJECT_NAME}
     src/CameraController.cpp
     src/HotkeyManager.cpp
     src/GeometryKernel/Curve.cpp
+    src/GeometryKernel/HalfEdgeMesh.cpp
+    src/GeometryKernel/MeshUtils.cpp
     src/GeometryKernel/Solid.cpp
     src/GeometryKernel/GeometryKernel.cpp
     src/GeometryKernel/Serialization.cpp

--- a/src/GeometryKernel/Curve.cpp
+++ b/src/GeometryKernel/Curve.cpp
@@ -1,5 +1,44 @@
 #include "Curve.h"
+#include "HalfEdgeMesh.h"
+#include "MeshUtils.h"
+#include <algorithm>
 
-Curve::Curve(const std::vector<Vector3>& pts) : points(pts) {
-    for (auto& p : const_cast<std::vector<Vector3>&>(points)) p.y = 0.0f;
+namespace {
+constexpr float kDefaultTolerance = 1e-4f;
+}
+
+Curve::Curve(std::vector<Vector3> loop, HalfEdgeMesh mesh)
+    : boundaryLoop(std::move(loop)), mesh(std::move(mesh)) {}
+
+std::unique_ptr<Curve> Curve::createFromPoints(const std::vector<Vector3>& pts) {
+    auto welded = MeshUtils::weldSequential(pts, kDefaultTolerance);
+    auto healed = MeshUtils::collapseTinyEdges(welded, kDefaultTolerance);
+    if (healed.size() < 3) {
+        return nullptr;
+    }
+
+    Vector3 normal = MeshUtils::computePolygonNormal(healed);
+    if (normal.length() <= 1e-6f) {
+        return nullptr;
+    }
+    if (normal.y < 0.0f) {
+        std::reverse(healed.begin(), healed.end());
+    }
+
+    HalfEdgeMesh mesh;
+    std::vector<int> loopIndices;
+    loopIndices.reserve(healed.size());
+    for (const auto& p : healed) {
+        loopIndices.push_back(mesh.addVertex(p));
+    }
+
+    if (mesh.addFace(loopIndices) < 0) {
+        return nullptr;
+    }
+
+    if (!mesh.isManifold()) {
+        return nullptr;
+    }
+
+    return std::unique_ptr<Curve>(new Curve(std::move(healed), std::move(mesh)));
 }

--- a/src/GeometryKernel/Curve.h
+++ b/src/GeometryKernel/Curve.h
@@ -1,12 +1,21 @@
 #pragma once
+#include <memory>
 #include <vector>
 #include "GeometryObject.h"
 
 class Curve : public GeometryObject {
 public:
-    explicit Curve(const std::vector<Vector3>& pts);
+    static std::unique_ptr<Curve> createFromPoints(const std::vector<Vector3>& pts);
+
     ObjectType getType() const override { return ObjectType::Curve; }
-    const std::vector<Vector3>& getPoints() const { return points; }
+    const HalfEdgeMesh& getMesh() const override { return mesh; }
+    HalfEdgeMesh& getMesh() override { return mesh; }
+
+    const std::vector<Vector3>& getBoundaryLoop() const { return boundaryLoop; }
+
 private:
-    std::vector<Vector3> points;
+    Curve(std::vector<Vector3> loop, HalfEdgeMesh mesh);
+
+    std::vector<Vector3> boundaryLoop;
+    HalfEdgeMesh mesh;
 };

--- a/src/GeometryKernel/GeometryKernel.cpp
+++ b/src/GeometryKernel/GeometryKernel.cpp
@@ -3,7 +3,10 @@
 #include <fstream>
 
 GeometryObject* GeometryKernel::addCurve(const std::vector<Vector3>& points) {
-    auto obj = std::make_unique<Curve>(points);
+    auto obj = Curve::createFromPoints(points);
+    if (!obj) {
+        return nullptr;
+    }
     GeometryObject* raw = obj.get();
     objects.push_back(std::move(obj));
     return raw;
@@ -11,9 +14,11 @@ GeometryObject* GeometryKernel::addCurve(const std::vector<Vector3>& points) {
 
 GeometryObject* GeometryKernel::extrudeCurve(GeometryObject* curveObj, float height) {
     if (!curveObj || curveObj->getType() != ObjectType::Curve) return nullptr;
-    const auto& pts = static_cast<Curve*>(curveObj)->getPoints();
-    if (pts.empty()) return nullptr;
-    auto obj = std::make_unique<Solid>(pts, height);
+    auto* curve = static_cast<Curve*>(curveObj);
+    auto obj = Solid::createFromCurve(*curve, height);
+    if (!obj) {
+        return nullptr;
+    }
     GeometryObject* raw = obj.get();
     objects.push_back(std::move(obj));
     return raw;

--- a/src/GeometryKernel/GeometryObject.h
+++ b/src/GeometryKernel/GeometryObject.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Vector3.h"
+#include "HalfEdgeMesh.h"
 
 enum class ObjectType { Curve, Solid };
 
@@ -7,6 +8,8 @@ class GeometryObject {
 public:
     virtual ~GeometryObject() = default;
     virtual ObjectType getType() const = 0;
+    virtual const HalfEdgeMesh& getMesh() const = 0;
+    virtual HalfEdgeMesh& getMesh() = 0;
     void setSelected(bool sel) { selected = sel; }
     bool isSelected() const { return selected; }
 private:

--- a/src/GeometryKernel/HalfEdgeMesh.cpp
+++ b/src/GeometryKernel/HalfEdgeMesh.cpp
@@ -1,0 +1,134 @@
+#include "HalfEdgeMesh.h"
+#include <algorithm>
+#include <utility>
+
+namespace {
+inline long long makeEdgeKey(int from, int to) {
+    return (static_cast<long long>(from) << 32) | static_cast<unsigned int>(to);
+}
+
+inline long long makeUndirectedKey(int a, int b) {
+    if (a > b) std::swap(a, b);
+    return (static_cast<long long>(a) << 32) | static_cast<unsigned int>(b);
+}
+}
+
+int HalfEdgeMesh::addVertex(const Vector3& position) {
+    int index = static_cast<int>(vertices.size());
+    vertices.push_back({ position, -1 });
+    return index;
+}
+
+int HalfEdgeMesh::addFace(const std::vector<int>& loop) {
+    if (loop.size() < 3) return -1;
+    int faceIndex = static_cast<int>(faces.size());
+    HalfEdgeFace face;
+    face.halfEdge = static_cast<int>(halfEdges.size());
+    faces.push_back(face);
+
+    size_t start = halfEdges.size();
+    size_t count = loop.size();
+    std::vector<std::pair<int, int>> touchedVertices;
+    std::vector<std::pair<int, int>> updatedOpposites;
+    std::vector<long long> insertedKeys;
+    touchedVertices.reserve(count);
+    updatedOpposites.reserve(count);
+    insertedKeys.reserve(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        int origin = loop[i];
+        int destination = loop[(i + 1) % count];
+        HalfEdgeRecord record;
+        record.origin = origin;
+        record.destination = destination;
+        record.face = faceIndex;
+        record.next = static_cast<int>(start + (i + 1) % count);
+        halfEdges.push_back(record);
+        int previous = vertices[origin].halfEdge;
+        if (previous == -1) {
+            touchedVertices.emplace_back(origin, previous);
+            vertices[origin].halfEdge = static_cast<int>(halfEdges.size() - 1);
+        }
+        long long key = makeEdgeKey(origin, destination);
+        auto it = directedEdgeMap.find(key);
+        if (it != directedEdgeMap.end()) {
+            // rollback and reject face
+            for (const auto& tv : touchedVertices) {
+                vertices[tv.first].halfEdge = tv.second;
+            }
+            for (const auto& oppEntry : updatedOpposites) {
+                halfEdges[oppEntry.first].opposite = oppEntry.second;
+            }
+            halfEdges.resize(start);
+            faces.pop_back();
+            for (long long inserted : insertedKeys) {
+                directedEdgeMap.erase(inserted);
+            }
+            return -1;
+        }
+        directedEdgeMap[key] = static_cast<int>(halfEdges.size() - 1);
+        insertedKeys.push_back(key);
+        long long oppositeKey = makeEdgeKey(destination, origin);
+        auto opp = directedEdgeMap.find(oppositeKey);
+        if (opp != directedEdgeMap.end()) {
+            int previousOpp = halfEdges[opp->second].opposite;
+            updatedOpposites.emplace_back(opp->second, previousOpp);
+            halfEdges[opp->second].opposite = static_cast<int>(halfEdges.size() - 1);
+            halfEdges.back().opposite = opp->second;
+        }
+    }
+
+    faces.back().normal = computeFaceNormal(loop);
+
+    // triangulate face using simple fan
+    if (loop.size() >= 3) {
+        for (size_t i = 1; i + 1 < loop.size(); ++i) {
+            HalfEdgeTriangle tri;
+            tri.v0 = loop[0];
+            tri.v1 = loop[i];
+            tri.v2 = loop[i + 1];
+            tri.normal = faces.back().normal;
+            triangles.push_back(tri);
+        }
+    }
+
+    return faceIndex;
+}
+
+void HalfEdgeMesh::clear() {
+    vertices.clear();
+    halfEdges.clear();
+    faces.clear();
+    triangles.clear();
+    directedEdgeMap.clear();
+}
+
+bool HalfEdgeMesh::isManifold() const {
+    std::unordered_map<long long, int> undirectedCounts;
+    for (size_t i = 0; i < halfEdges.size(); ++i) {
+        const auto& edge = halfEdges[i];
+        if (edge.origin < 0 || edge.destination < 0) continue;
+        long long key = makeUndirectedKey(edge.origin, edge.destination);
+        int count = ++undirectedCounts[key];
+        if (count > 2) return false;
+        if (count == 2) {
+            if (edge.opposite == -1) return false;
+            const auto& opp = halfEdges[edge.opposite];
+            if (opp.opposite != static_cast<int>(i)) return false;
+        }
+    }
+    return true;
+}
+
+Vector3 HalfEdgeMesh::computeFaceNormal(const std::vector<int>& loop) const {
+    Vector3 normal(0.0f, 0.0f, 0.0f);
+    if (loop.size() < 3) return normal;
+    for (size_t i = 0; i < loop.size(); ++i) {
+        const Vector3& current = vertices[loop[i]].position;
+        const Vector3& next = vertices[loop[(i + 1) % loop.size()]].position;
+        normal.x += (current.y - next.y) * (current.z + next.z);
+        normal.y += (current.z - next.z) * (current.x + next.x);
+        normal.z += (current.x - next.x) * (current.y + next.y);
+    }
+    return normal.normalized();
+}

--- a/src/GeometryKernel/HalfEdgeMesh.h
+++ b/src/GeometryKernel/HalfEdgeMesh.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <vector>
+#include <unordered_map>
+#include "Vector3.h"
+
+struct HalfEdgeVertex {
+    Vector3 position;
+    int halfEdge = -1;
+};
+
+struct HalfEdgeRecord {
+    int origin = -1;
+    int destination = -1;
+    int face = -1;
+    int next = -1;
+    int opposite = -1;
+};
+
+struct HalfEdgeFace {
+    int halfEdge = -1;
+    Vector3 normal;
+};
+
+struct HalfEdgeTriangle {
+    int v0 = -1;
+    int v1 = -1;
+    int v2 = -1;
+    Vector3 normal;
+};
+
+class HalfEdgeMesh {
+public:
+    int addVertex(const Vector3& position);
+    int addFace(const std::vector<int>& loop);
+    void clear();
+
+    bool isManifold() const;
+
+    const std::vector<HalfEdgeVertex>& getVertices() const { return vertices; }
+    std::vector<HalfEdgeVertex>& getVertices() { return vertices; }
+
+    const std::vector<HalfEdgeRecord>& getHalfEdges() const { return halfEdges; }
+    const std::vector<HalfEdgeFace>& getFaces() const { return faces; }
+    const std::vector<HalfEdgeTriangle>& getTriangles() const { return triangles; }
+
+private:
+    Vector3 computeFaceNormal(const std::vector<int>& loop) const;
+
+    std::vector<HalfEdgeVertex> vertices;
+    std::vector<HalfEdgeRecord> halfEdges;
+    std::vector<HalfEdgeFace> faces;
+    std::vector<HalfEdgeTriangle> triangles;
+    std::unordered_map<long long, int> directedEdgeMap;
+};

--- a/src/GeometryKernel/MeshUtils.cpp
+++ b/src/GeometryKernel/MeshUtils.cpp
@@ -1,0 +1,67 @@
+#include "MeshUtils.h"
+#include <algorithm>
+
+namespace MeshUtils {
+
+bool nearlyEqual(const Vector3& a, const Vector3& b, float epsilon) {
+    return distanceSquared(a, b) <= epsilon * epsilon;
+}
+
+float distanceSquared(const Vector3& a, const Vector3& b) {
+    float dx = a.x - b.x;
+    float dy = a.y - b.y;
+    float dz = a.z - b.z;
+    return dx * dx + dy * dy + dz * dz;
+}
+
+std::vector<Vector3> weldSequential(const std::vector<Vector3>& pts, float epsilon) {
+    std::vector<Vector3> result;
+    result.reserve(pts.size());
+    for (const auto& p : pts) {
+        Vector3 projected(p.x, 0.0f, p.z);
+        if (result.empty() || !nearlyEqual(projected, result.back(), epsilon)) {
+            result.push_back(projected);
+        }
+    }
+    if (result.size() > 1 && nearlyEqual(result.front(), result.back(), epsilon)) {
+        result.pop_back();
+    }
+    return result;
+}
+
+std::vector<Vector3> collapseTinyEdges(const std::vector<Vector3>& pts, float minEdge) {
+    if (pts.size() < 3) return pts;
+    std::vector<Vector3> working = pts;
+    bool changed = true;
+    float minEdgeSq = minEdge * minEdge;
+    while (changed && working.size() >= 3) {
+        changed = false;
+        for (size_t i = 0; i < working.size(); ++i) {
+            size_t j = (i + 1) % working.size();
+            if (distanceSquared(working[i], working[j]) < minEdgeSq) {
+                working.erase(working.begin() + static_cast<long long>(j));
+                changed = true;
+                break;
+            }
+        }
+    }
+    if (working.size() > 1 && nearlyEqual(working.front(), working.back(), minEdge)) {
+        working.pop_back();
+    }
+    return working;
+}
+
+Vector3 computePolygonNormal(const std::vector<Vector3>& polygon) {
+    Vector3 normal(0.0f, 0.0f, 0.0f);
+    if (polygon.size() < 3) return normal;
+    for (size_t i = 0; i < polygon.size(); ++i) {
+        const Vector3& current = polygon[i];
+        const Vector3& next = polygon[(i + 1) % polygon.size()];
+        normal.x += (current.y - next.y) * (current.z + next.z);
+        normal.y += (current.z - next.z) * (current.x + next.x);
+        normal.z += (current.x - next.x) * (current.y + next.y);
+    }
+    return normal.normalized();
+}
+
+}

--- a/src/GeometryKernel/MeshUtils.h
+++ b/src/GeometryKernel/MeshUtils.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <vector>
+#include "Vector3.h"
+
+namespace MeshUtils {
+bool nearlyEqual(const Vector3& a, const Vector3& b, float epsilon = 1e-5f);
+float distanceSquared(const Vector3& a, const Vector3& b);
+std::vector<Vector3> weldSequential(const std::vector<Vector3>& pts, float epsilon = 1e-5f);
+std::vector<Vector3> collapseTinyEdges(const std::vector<Vector3>& pts, float minEdge = 1e-4f);
+Vector3 computePolygonNormal(const std::vector<Vector3>& polygon);
+}

--- a/src/GeometryKernel/Serialization.cpp
+++ b/src/GeometryKernel/Serialization.cpp
@@ -8,7 +8,7 @@
 namespace GeometryIO {
 
 void writeCurve(std::ostream& os, const Curve& curve) {
-    const auto& pts = curve.getPoints();
+    const auto& pts = curve.getBoundaryLoop();
     os << "Curve " << pts.size() << "\n";
     for (const auto& p : pts) {
         os << p.x << ' ' << p.y << ' ' << p.z << "\n";
@@ -21,16 +21,14 @@ std::unique_ptr<Curve> readCurve(std::istream& is) {
     for (size_t i=0;i<n;++i) {
         Vector3 p; is >> p.x >> p.y >> p.z; pts.push_back(p);
     }
-    return std::make_unique<Curve>(pts);
+    return Curve::createFromPoints(pts);
 }
 
 void writeSolid(std::ostream& os, const Solid& solid) {
-    const auto& verts = solid.getVertices();
-    size_t N = verts.size()/2; // base ring count
-    os << "Solid " << N << ' ' << (N?verts[N].y:0.0f) << "\n";
-    for (size_t i=0;i<N;++i) {
-        const auto& p = verts[i];
-        os << p.x << ' ' << 0.0f << ' ' << p.z << "\n";
+    const auto& base = solid.getBaseLoop();
+    os << "Solid " << base.size() << ' ' << solid.getHeight() << "\n";
+    for (const auto& p : base) {
+        os << p.x << ' ' << p.y << ' ' << p.z << "\n";
     }
 }
 
@@ -40,7 +38,7 @@ std::unique_ptr<Solid> readSolid(std::istream& is) {
     for (size_t i=0;i<n;++i) {
         Vector3 p; is >> p.x >> p.y >> p.z; base.push_back(Vector3(p.x,0.0f,p.z));
     }
-    return std::make_unique<Solid>(base, h);
+    return Solid::createFromProfile(base, h);
 }
 
 } // namespace

--- a/src/GeometryKernel/Solid.h
+++ b/src/GeometryKernel/Solid.h
@@ -1,16 +1,27 @@
 #pragma once
+#include <memory>
 #include <vector>
 #include "GeometryObject.h"
 #include "Vector3.h"
 
+class Curve;
+
 class Solid : public GeometryObject {
 public:
-    struct Face { std::vector<int> indices; };
-    Solid(const std::vector<Vector3>& baseProfile, float height);
+    static std::unique_ptr<Solid> createFromProfile(const std::vector<Vector3>& baseProfile, float height);
+    static std::unique_ptr<Solid> createFromCurve(const Curve& curve, float height);
+
     ObjectType getType() const override { return ObjectType::Solid; }
-    const std::vector<Vector3>& getVertices() const { return vertices; }
-    const std::vector<Face>& getFaces() const { return faces; }
+    const HalfEdgeMesh& getMesh() const override { return mesh; }
+    HalfEdgeMesh& getMesh() override { return mesh; }
+
+    const std::vector<Vector3>& getBaseLoop() const { return baseLoop; }
+    float getHeight() const { return height; }
+
 private:
-    std::vector<Vector3> vertices;
-    std::vector<Face> faces;
+    Solid(std::vector<Vector3> baseLoop, float height, HalfEdgeMesh mesh);
+
+    std::vector<Vector3> baseLoop;
+    float height = 0.0f;
+    HalfEdgeMesh mesh;
 };

--- a/tests/test_geometry.cpp
+++ b/tests/test_geometry.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cmath>
 #include <vector>
 
 #include "GeometryKernel.h"
@@ -7,32 +8,61 @@
 
 int main() {
     GeometryKernel kernel;
+
+    // invalid curve rejected
+    assert(kernel.addCurve({}) == nullptr);
+
     std::vector<Vector3> pts{
         {0.0f, 0.0f, 0.0f},
+        {0.0f, 0.0f, 0.0f}, // duplicate
         {1.0f, 0.0f, 0.0f},
+        {1.0f, 0.0f, 0.00001f}, // tiny edge
         {1.0f, 0.0f, 1.0f},
-        {0.0f, 0.0f, 1.0f}
+        {0.0f, 0.0f, 1.0f},
+        {0.0f, 0.0f, 0.0f} // closing duplicate
     };
 
-    // addCurve
     GeometryObject* curveObj = kernel.addCurve(pts);
     assert(curveObj);
     assert(kernel.getObjects().size() == 1);
     assert(curveObj->getType() == ObjectType::Curve);
     auto* curve = static_cast<Curve*>(curveObj);
-    assert(curve->getPoints().size() == pts.size());
+    const auto& boundary = curve->getBoundaryLoop();
+    assert(boundary.size() == 4); // duplicates and tiny edges collapsed
 
-    // extrudeCurve
+    const auto& curveMesh = curve->getMesh();
+    assert(curveMesh.isManifold());
+    assert(curveMesh.getFaces().size() == 1);
+    assert(curveMesh.getTriangles().size() == 2);
+    assert(curveMesh.getFaces()[0].normal.y > 0.9f);
+
     float height = 2.0f;
     GeometryObject* solidObj = kernel.extrudeCurve(curveObj, height);
     assert(solidObj);
     assert(solidObj->getType() == ObjectType::Solid);
     assert(kernel.getObjects().size() == 2);
     auto* solid = static_cast<Solid*>(solidObj);
-    size_t expected = pts.size() + 1; // profile closed by Solid
-    assert(solid->getVertices().size() == expected * 2);
+    assert(std::fabs(solid->getHeight() - height) < 1e-6f);
+    assert(solid->getBaseLoop().size() == boundary.size());
 
-    // deleteObject
+    const auto& solidMesh = solid->getMesh();
+    assert(solidMesh.isManifold());
+    size_t loopSize = boundary.size();
+    assert(solidMesh.getVertices().size() == loopSize * 2);
+    assert(solidMesh.getFaces().size() == loopSize + 2);
+    assert(solidMesh.getTriangles().size() == 4 * loopSize - 4);
+
+    bool foundTop = false;
+    bool foundBottom = false;
+    for (const auto& face : solidMesh.getFaces()) {
+        if (face.normal.y > 0.9f) foundTop = true;
+        if (face.normal.y < -0.9f) foundBottom = true;
+    }
+    assert(foundTop && foundBottom);
+
+    // tiny extrusion ignored
+    assert(kernel.extrudeCurve(curveObj, 1e-5f) == nullptr);
+
     kernel.deleteObject(curveObj);
     assert(kernel.getObjects().size() == 1);
     assert(kernel.getObjects()[0].get() == solidObj);


### PR DESCRIPTION
## Summary
- add a half-edge mesh core with vertex/face records, triangulation support, and manifold validation utilities
- update curve/solid creation, serialization, and geometry kernel flows to build healed meshes with welded duplicates and consistent normals
- expand geometry unit tests to cover manifold creation, healing routines, and extrusion behaviour

## Testing
- ./build/test_geometry

------
https://chatgpt.com/codex/tasks/task_e_68dc1ca052ec832184ad04a7446483dc