### PR TITLE
Add inference engine and viewport overlay support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,12 @@ add_executable(${PROJECT_NAME}
     src/Tools/SketchTool.cpp
     src/Tools/ExtrudeTool.cpp
     src/Tools/ToolManager.cpp
+    src/Interaction/InferenceEngine.cpp
     src/ui/MeasurementWidget.cpp
     resources.qrc
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE src src/GeometryKernel src/Tools src/ui)
+target_include_directories(${PROJECT_NAME} PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
 # Installation
 install(TARGETS ${PROJECT_NAME}

--- a/src/GLViewport.cpp
+++ b/src/GLViewport.cpp
@@ -13,6 +13,8 @@
 #include "Tools/ToolManager.h"
 #include "GeometryKernel/Curve.h"
 #include "GeometryKernel/Solid.h"
+#include "GeometryKernel/Vector3.h"
+#include "Interaction/InferenceEngine.h"
 
 GLViewport::GLViewport(QWidget* parent)
     : QOpenGLWidget(parent)
@@ -69,6 +71,9 @@ void GLViewport::paintGL()
     float right = top * aspect;
     glFrustum(-right, right, -top, top, znear, zfar);
 
+    QMatrix4x4 projectionMatrix;
+    projectionMatrix.perspective(fov, aspect, znear, zfar);
+
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 
@@ -83,6 +88,9 @@ void GLViewport::paintGL()
     QVector3D s = QVector3D::crossProduct(f, up); s.normalize();
     QVector3D u = QVector3D::crossProduct(s, f);
 
+    QMatrix4x4 viewMatrix;
+    viewMatrix.lookAt(eye, center, QVector3D(0.0f, 1.0f, 0.0f));
+
     float M[16] = {
         s.x(),  u.x(),  -f.x(),  0,
         s.y(),  u.y(),  -f.y(),  0,
@@ -93,6 +101,21 @@ void GLViewport::paintGL()
         1
     };
     glMultMatrixf(M);
+
+    if (toolManager) {
+        ToolInferenceUpdateRequest request;
+        if (hasDeviceMouse) {
+            QVector3D rayOrigin;
+            QVector3D rayDirection;
+            if (computePickRay(lastDeviceMouse, rayOrigin, rayDirection)) {
+                request.hasRay = true;
+                request.ray.origin = Vector3(rayOrigin.x(), rayOrigin.y(), rayOrigin.z());
+                request.ray.direction = Vector3(rayDirection.x(), rayDirection.y(), rayDirection.z());
+                request.pixelRadius = 6.0f;
+            }
+        }
+        toolManager->updateInference(request);
+    }
 
     drawGrid();
     drawAxes();
@@ -112,6 +135,7 @@ void GLViewport::paintGL()
 
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
+    drawInferenceOverlay(painter, projectionMatrix, viewMatrix);
     painter.setPen(QColor(231, 234, 240));
     painter.setBrush(QColor(11, 13, 16, 220));
     QRect hudRect(12, 12, 200, 60);
@@ -217,6 +241,144 @@ void GLViewport::drawScene()
     }
 }
 
+bool GLViewport::computePickRay(const QPoint& devicePos, QVector3D& origin, QVector3D& direction) const
+{
+    if (width() <= 0 || height() <= 0) {
+        return false;
+    }
+
+    const float ratio = devicePixelRatioF();
+    const float pixelWidth = std::max(1.0f, static_cast<float>(width()) * ratio);
+    const float pixelHeight = std::max(1.0f, static_cast<float>(height()) * ratio);
+    float nx = ((static_cast<float>(devicePos.x()) + 0.5f) / pixelWidth) * 2.0f - 1.0f;
+    float ny = 1.0f - ((static_cast<float>(devicePos.y()) + 0.5f) / pixelHeight) * 2.0f;
+
+    QMatrix4x4 projection;
+    const float aspect = width() > 0 ? static_cast<float>(width()) / static_cast<float>(height() > 0 ? height() : 1) : 1.0f;
+    projection.perspective(60.0f, aspect, 0.1f, 1000.0f);
+
+    float cx, cy, cz;
+    camera.getCameraPosition(cx, cy, cz);
+    float tx, ty, tz;
+    camera.getTarget(tx, ty, tz);
+
+    QMatrix4x4 view;
+    view.lookAt(QVector3D(cx, cy, cz), QVector3D(tx, ty, tz), QVector3D(0.0f, 1.0f, 0.0f));
+
+    bool invertible = false;
+    QMatrix4x4 inv = (projection * view).inverted(&invertible);
+    if (!invertible) {
+        return false;
+    }
+
+    QVector4D nearPoint(nx, ny, -1.0f, 1.0f);
+    QVector4D farPoint(nx, ny, 1.0f, 1.0f);
+    QVector4D worldNear = inv * nearPoint;
+    QVector4D worldFar = inv * farPoint;
+    if (qFuzzyIsNull(worldNear.w()) || qFuzzyIsNull(worldFar.w())) {
+        return false;
+    }
+    worldNear /= worldNear.w();
+    worldFar /= worldFar.w();
+
+    origin = worldNear.toVector3DAffine();
+    direction = (worldFar - worldNear).toVector3D();
+    if (qFuzzyIsNull(direction.lengthSquared())) {
+        return false;
+    }
+    direction.normalize();
+    return true;
+}
+
+bool GLViewport::projectWorldToScreen(const QVector3D& world, const QMatrix4x4& projection, const QMatrix4x4& view, QPointF& out) const
+{
+    QVector4D clip = projection * view * QVector4D(world, 1.0f);
+    if (qFuzzyIsNull(clip.w())) {
+        return false;
+    }
+    clip /= clip.w();
+    QVector3D ndc = clip.toVector3D();
+    if (ndc.z() < 0.0f || ndc.z() > 1.0f) {
+        return false;
+    }
+    float sx = (ndc.x() * 0.5f + 0.5f) * static_cast<float>(width());
+    float sy = (-ndc.y() * 0.5f + 0.5f) * static_cast<float>(height());
+    out = QPointF(sx, sy);
+    return true;
+}
+
+void GLViewport::drawInferenceOverlay(QPainter& painter, const QMatrix4x4& projection, const QMatrix4x4& view)
+{
+    if (!toolManager) {
+        return;
+    }
+
+    const auto& inference = toolManager->getCurrentInference();
+    if (!inference.isValid()) {
+        return;
+    }
+
+    auto toVector3D = [](const Vector3& v) { return QVector3D(v.x, v.y, v.z); };
+
+    QPointF screenPoint;
+    if (!projectWorldToScreen(toVector3D(inference.position), projection, view, screenPoint)) {
+        return;
+    }
+
+    auto colorForType = [](Interaction::InferenceSnapType type) {
+        switch (type) {
+        case Interaction::InferenceSnapType::Endpoint: return QColor(216, 57, 49);
+        case Interaction::InferenceSnapType::Midpoint: return QColor(38, 132, 255);
+        case Interaction::InferenceSnapType::Intersection: return QColor(140, 46, 201);
+        case Interaction::InferenceSnapType::FaceCenter: return QColor(255, 176, 29);
+        case Interaction::InferenceSnapType::OnEdge: return QColor(26, 188, 156);
+        case Interaction::InferenceSnapType::OnFace: return QColor(241, 196, 15);
+        case Interaction::InferenceSnapType::Axis: return QColor(52, 152, 219);
+        case Interaction::InferenceSnapType::Parallel: return QColor(231, 76, 60);
+        case Interaction::InferenceSnapType::Perpendicular: return QColor(155, 89, 182);
+        default: return QColor(255, 255, 255);
+        }
+    };
+
+    QColor color = colorForType(inference.type);
+    QColor fill = color;
+    fill.setAlpha(180);
+
+    painter.setPen(QPen(color, 1.8f));
+    painter.setBrush(fill);
+    painter.drawEllipse(screenPoint, 6.0, 6.0);
+
+    const QString label = QString::fromLatin1(Interaction::toString(inference.type)) +
+        (inference.locked ? tr(" (locked)") : QString());
+    painter.setPen(QPen(Qt::black, 1.0));
+    painter.drawText(screenPoint + QPointF(10.0, -10.0), label);
+
+    Vector3 dir = inference.direction;
+    if (dir.lengthSquared() > 1e-6f) {
+        Vector3 normDir = dir.normalized();
+        Vector3 start = inference.position - normDir * 0.4f;
+        Vector3 end = inference.position + normDir * 0.4f;
+        QPointF startPoint;
+        QPointF endPoint;
+        if (projectWorldToScreen(toVector3D(start), projection, view, startPoint) &&
+            projectWorldToScreen(toVector3D(end), projection, view, endPoint)) {
+            QPen pen(color, 1.6f, Qt::DashLine, Qt::RoundCap, Qt::RoundJoin);
+            pen.setDashPattern({ 4.0, 4.0 });
+            painter.setPen(pen);
+            painter.drawLine(startPoint, endPoint);
+        }
+    }
+
+    if (inference.type == Interaction::InferenceSnapType::Axis) {
+        QPointF anchorPoint;
+        if (projectWorldToScreen(toVector3D(inference.reference), projection, view, anchorPoint)) {
+            QPen anchorPen(color, 1.2f, Qt::DashDotLine, Qt::RoundCap, Qt::RoundJoin);
+            painter.setPen(anchorPen);
+            painter.drawLine(anchorPoint, screenPoint);
+        }
+    }
+}
+
 void GLViewport::mousePressEvent(QMouseEvent* e)
 {
     lastMouse = e->pos();
@@ -229,6 +391,8 @@ void GLViewport::mousePressEvent(QMouseEvent* e)
         if (auto* t = toolManager->getActiveTool()) {
             const auto ratio = devicePixelRatioF();
             const QPointF devicePos = e->position() * ratio;
+            lastDeviceMouse = QPoint(std::lround(devicePos.x()), std::lround(devicePos.y()));
+            hasDeviceMouse = true;
             t->onMouseDown(std::lround(devicePos.x()), std::lround(devicePos.y()));
         }
     }
@@ -238,6 +402,11 @@ void GLViewport::mouseMoveEvent(QMouseEvent* e)
 {
     QPoint delta = e->pos() - lastMouse;
     lastMouse = e->pos();
+
+    const auto ratio = devicePixelRatioF();
+    const QPointF devicePos = e->position() * ratio;
+    lastDeviceMouse = QPoint(std::lround(devicePos.x()), std::lround(devicePos.y()));
+    hasDeviceMouse = true;
 
     if (rotating) {
         camera.rotateCamera(delta.x(), delta.y());
@@ -250,8 +419,6 @@ void GLViewport::mouseMoveEvent(QMouseEvent* e)
 
     if (toolManager) {
         if (auto* t = toolManager->getActiveTool()) {
-            const auto ratio = devicePixelRatioF();
-            const QPointF devicePos = e->position() * ratio;
             t->onMouseMove(std::lround(devicePos.x()), std::lround(devicePos.y()));
         }
     }
@@ -271,6 +438,8 @@ void GLViewport::mouseReleaseEvent(QMouseEvent* e)
         if (auto* t = toolManager->getActiveTool()) {
             const auto ratio = devicePixelRatioF();
             const QPointF devicePos = e->position() * ratio;
+            lastDeviceMouse = QPoint(std::lround(devicePos.x()), std::lround(devicePos.y()));
+            hasDeviceMouse = true;
             t->onMouseUp(std::lround(devicePos.x()), std::lround(devicePos.y()));
         }
     }
@@ -285,15 +454,28 @@ void GLViewport::wheelEvent(QWheelEvent* e)
 void GLViewport::keyPressEvent(QKeyEvent* e)
 {
     if (toolManager) {
-        if (auto* t = toolManager->getActiveTool()) {
-            t->onKeyPress(static_cast<char>(e->key()));
-        }
+        toolManager->handleKeyPress(e->key());
     }
+    QOpenGLWidget::keyPressEvent(e);
+    update();
+}
+
+void GLViewport::keyReleaseEvent(QKeyEvent* e)
+{
+    if (toolManager) {
+        toolManager->handleKeyRelease(e->key());
+    }
+    QOpenGLWidget::keyReleaseEvent(e);
+    update();
 }
 
 void GLViewport::leaveEvent(QEvent* event)
 {
     QOpenGLWidget::leaveEvent(event);
+    hasDeviceMouse = false;
+    if (toolManager) {
+        toolManager->clearInference();
+    }
     emit cursorPositionChanged(std::numeric_limits<double>::quiet_NaN(),
                                std::numeric_limits<double>::quiet_NaN(),
                                std::numeric_limits<double>::quiet_NaN());

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -37,6 +37,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent* e) override;
     void wheelEvent(QWheelEvent* e) override;
     void keyPressEvent(QKeyEvent* e) override;
+    void keyReleaseEvent(QKeyEvent* e) override;
     void leaveEvent(QEvent* event) override;
 
 private:
@@ -44,12 +45,17 @@ private:
     void drawGrid();
     void drawScene();
     bool projectCursorToGround(const QPointF& pos, QVector3D& world) const;
+    bool computePickRay(const QPoint& devicePos, QVector3D& origin, QVector3D& direction) const;
+    bool projectWorldToScreen(const QVector3D& world, const QMatrix4x4& projection, const QMatrix4x4& view, QPointF& out) const;
+    void drawInferenceOverlay(QPainter& painter, const QMatrix4x4& projection, const QMatrix4x4& view);
 
     GeometryKernel geometry;
     CameraController camera;
     ToolManager* toolManager = nullptr;
 
     QPoint lastMouse;
+    QPoint lastDeviceMouse;
+    bool hasDeviceMouse = false;
     bool rotating = false;
     bool panning = false;
 

--- a/src/GeometryKernel/Vector3.h
+++ b/src/GeometryKernel/Vector3.h
@@ -7,10 +7,15 @@ public:
     Vector3() : x(0), y(0), z(0) {}
     Vector3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
     float length() const { return std::sqrt(x*x + y*y + z*z); }
+    float lengthSquared() const { return x*x + y*y + z*z; }
     Vector3 normalized() const { float l = length(); return l>1e-6f ? Vector3(x/l,y/l,z/l) : Vector3(); }
     float dot(const Vector3& o) const { return x*o.x + y*o.y + z*o.z; }
     Vector3 cross(const Vector3& o) const { return Vector3(y*o.z - z*o.y, z*o.x - x*o.z, x*o.y - y*o.x); }
     Vector3 operator+(const Vector3& o) const { return Vector3(x+o.x, y+o.y, z+o.z); }
     Vector3 operator-(const Vector3& o) const { return Vector3(x-o.x, y-o.y, z-o.z); }
     Vector3 operator*(float s) const { return Vector3(x*s, y*s, z*s); }
+    Vector3 operator/(float s) const { return Vector3(x/s, y/s, z/s); }
+    Vector3& operator+=(const Vector3& o) { x += o.x; y += o.y; z += o.z; return *this; }
+    Vector3& operator-=(const Vector3& o) { x -= o.x; y -= o.y; z -= o.z; return *this; }
+    Vector3& operator*=(float s) { x *= s; y *= s; z *= s; return *this; }
 };

--- a/src/Interaction/InferenceEngine.cpp
+++ b/src/Interaction/InferenceEngine.cpp
@@ -1,0 +1,591 @@
+#include "InferenceEngine.h"
+
+#include "../GeometryKernel/GeometryKernel.h"
+#include "../GeometryKernel/GeometryObject.h"
+#include "../GeometryKernel/HalfEdgeMesh.h"
+#include "../GeometryKernel/Curve.h"
+#include "../GeometryKernel/Solid.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <unordered_set>
+
+namespace Interaction {
+namespace {
+
+constexpr float kEpsilon = 1e-5f;
+constexpr float kPointSnapRadius = 0.12f;
+constexpr float kMidpointSnapRadius = 0.15f;
+constexpr float kEdgeSnapRadius = 0.18f;
+constexpr float kFaceSnapRadius = 0.24f;
+constexpr float kParallelThreshold = 0.9848f; // cos(10 deg)
+constexpr float kPerpendicularThreshold = 0.0872f; // sin(5 deg)
+
+float component(const Vector3& v, int axis)
+{
+    switch (axis) {
+    case 0: return v.x;
+    case 1: return v.y;
+    default: return v.z;
+    }
+}
+
+Vector3 normalizeOrZero(const Vector3& v)
+{
+    float len = v.length();
+    if (len <= kEpsilon) {
+        return Vector3();
+    }
+    return v / len;
+}
+
+float distancePointToRaySquared(const Vector3& point, const PickRay& ray, float& outRayT)
+{
+    Vector3 diff = point - ray.origin;
+    outRayT = diff.dot(ray.direction);
+    if (outRayT < 0.0f) {
+        outRayT = 0.0f;
+    }
+    Vector3 projected = ray.origin + ray.direction * outRayT;
+    Vector3 delta = point - projected;
+    return delta.lengthSquared();
+}
+
+float distancePointToRaySquared(const Vector3& point, const PickRay& ray)
+{
+    float t = 0.0f;
+    return distancePointToRaySquared(point, ray, t);
+}
+
+float distanceToBoundsSquared(const Vector3& point, const Vector3& minBounds, const Vector3& maxBounds)
+{
+    float dx = 0.0f;
+    if (point.x < minBounds.x) dx = minBounds.x - point.x;
+    else if (point.x > maxBounds.x) dx = point.x - maxBounds.x;
+    float dy = 0.0f;
+    if (point.y < minBounds.y) dy = minBounds.y - point.y;
+    else if (point.y > maxBounds.y) dy = point.y - maxBounds.y;
+    float dz = 0.0f;
+    if (point.z < minBounds.z) dz = minBounds.z - point.z;
+    else if (point.z > maxBounds.z) dz = point.z - maxBounds.z;
+    return dx*dx + dy*dy + dz*dz;
+}
+
+struct LineIntersection {
+    bool valid = false;
+    Vector3 pointOnRay;
+    Vector3 pointOnSegment;
+    float rayT = 0.0f;
+    float segmentT = 0.0f;
+    float distanceSquared = std::numeric_limits<float>::infinity();
+};
+
+LineIntersection closestBetweenRayAndSegment(const PickRay& ray, const Vector3& a, const Vector3& b)
+{
+    LineIntersection result;
+    Vector3 v = b - a;
+    Vector3 w0 = ray.origin - a;
+    float aDot = ray.direction.dot(ray.direction);
+    float bDot = ray.direction.dot(v);
+    float cDot = v.dot(v);
+    float dDot = ray.direction.dot(w0);
+    float eDot = v.dot(w0);
+    float denom = aDot * cDot - bDot * bDot;
+    float s = 0.0f;
+    float t = 0.0f;
+    if (std::fabs(denom) < kEpsilon) {
+        // almost parallel, project onto segment
+        t = std::clamp(-eDot / (cDot > kEpsilon ? cDot : 1.0f), 0.0f, 1.0f);
+        s = 0.0f;
+    } else {
+        s = (bDot * eDot - cDot * dDot) / denom;
+        t = (aDot * eDot - bDot * dDot) / denom;
+        if (t < 0.0f) {
+            t = 0.0f;
+            s = -dDot / (aDot > kEpsilon ? aDot : 1.0f);
+        } else if (t > 1.0f) {
+            t = 1.0f;
+            s = (bDot - dDot) / (aDot > kEpsilon ? aDot : 1.0f);
+        }
+        if (s < 0.0f) s = 0.0f;
+    }
+    result.pointOnRay = ray.origin + ray.direction * s;
+    result.pointOnSegment = a + v * t;
+    Vector3 delta = result.pointOnSegment - result.pointOnRay;
+    result.distanceSquared = delta.lengthSquared();
+    result.rayT = s;
+    result.segmentT = t;
+    result.valid = true;
+    return result;
+}
+
+float biasForType(InferenceSnapType type)
+{
+    switch (type) {
+    case InferenceSnapType::Endpoint: return 0.1f;
+    case InferenceSnapType::Intersection: return 0.05f;
+    case InferenceSnapType::Midpoint: return 0.2f;
+    case InferenceSnapType::FaceCenter: return 0.25f;
+    case InferenceSnapType::OnEdge: return 0.3f;
+    case InferenceSnapType::Parallel: return 0.32f;
+    case InferenceSnapType::Perpendicular: return 0.34f;
+    case InferenceSnapType::OnFace: return 0.4f;
+    case InferenceSnapType::Axis: return 0.0f;
+    default: return 1.0f;
+    }
+}
+
+long long makeUndirectedKey(int a, int b)
+{
+    if (a > b) std::swap(a, b);
+    return (static_cast<long long>(a) << 32) | static_cast<unsigned int>(b);
+}
+
+} // namespace
+
+struct InferenceEngine::FaceFeature {
+    Vector3 center;
+    Vector3 normal;
+    float radiusSquared = 0.0f;
+};
+
+struct InferenceEngine::EdgeFeature {
+    Vector3 a;
+    Vector3 b;
+    Vector3 midpoint;
+    Vector3 direction;
+};
+
+class InferenceEngine::SimpleKdTree {
+public:
+    void build(const std::vector<Vector3>* pts)
+    {
+        points = pts;
+        indices.clear();
+        nodes.clear();
+        if (!points || points->empty()) {
+            return;
+        }
+        indices.resize(points->size());
+        std::iota(indices.begin(), indices.end(), 0);
+        nodes.reserve(points->size() * 2);
+        buildRecursive(0, static_cast<int>(indices.size()));
+    }
+
+    int nearest(const Vector3& target, float maxDistSq) const
+    {
+        if (!points || points->empty() || nodes.empty()) {
+            return -1;
+        }
+        int bestIndex = -1;
+        float bestDistSq = maxDistSq;
+        nearestRecursive(0, target, bestDistSq, bestIndex);
+        return bestIndex;
+    }
+
+private:
+    struct Node {
+        int axis = -1;
+        int left = -1;
+        int right = -1;
+        int start = 0;
+        int end = 0;
+        int mid = -1;
+        float split = 0.0f;
+        Vector3 minBounds;
+        Vector3 maxBounds;
+    };
+
+    const std::vector<Vector3>* points = nullptr;
+    std::vector<int> indices;
+    std::vector<Node> nodes;
+
+    int buildRecursive(int start, int end)
+    {
+        Node node;
+        node.start = start;
+        node.end = end;
+        node.left = -1;
+        node.right = -1;
+        node.mid = -1;
+
+        Vector3 minB = (*points)[indices[start]];
+        Vector3 maxB = minB;
+        for (int i = start + 1; i < end; ++i) {
+            const Vector3& p = (*points)[indices[i]];
+            if (p.x < minB.x) minB.x = p.x;
+            if (p.y < minB.y) minB.y = p.y;
+            if (p.z < minB.z) minB.z = p.z;
+            if (p.x > maxB.x) maxB.x = p.x;
+            if (p.y > maxB.y) maxB.y = p.y;
+            if (p.z > maxB.z) maxB.z = p.z;
+        }
+        node.minBounds = minB;
+        node.maxBounds = maxB;
+
+        int count = end - start;
+        int nodeIndex = static_cast<int>(nodes.size());
+        nodes.push_back(node);
+
+        if (count <= 12) {
+            nodes[nodeIndex] = node;
+            return nodeIndex;
+        }
+
+        Vector3 extents(maxB.x - minB.x, maxB.y - minB.y, maxB.z - minB.z);
+        int axis = 0;
+        if (extents.y > extents.x && extents.y >= extents.z) axis = 1;
+        else if (extents.z > extents.x && extents.z >= extents.y) axis = 2;
+
+        int mid = start + count / 2;
+        auto begin = indices.begin() + start;
+        auto nth = indices.begin() + mid;
+        auto endIt = indices.begin() + end;
+        std::nth_element(begin, nth, endIt, [&](int lhs, int rhs) {
+            return component((*points)[lhs], axis) < component((*points)[rhs], axis);
+        });
+
+        nodes[nodeIndex].axis = axis;
+        nodes[nodeIndex].mid = mid;
+        nodes[nodeIndex].split = component((*points)[indices[mid]], axis);
+        nodes[nodeIndex].minBounds = minB;
+        nodes[nodeIndex].maxBounds = maxB;
+        nodes[nodeIndex].left = buildRecursive(start, mid);
+        nodes[nodeIndex].right = buildRecursive(mid, end);
+        return nodeIndex;
+    }
+
+    void nearestRecursive(int nodeIndex, const Vector3& target, float& bestDistSq, int& bestIndex) const
+    {
+        const Node& node = nodes[nodeIndex];
+        if (node.axis < 0 || node.mid < 0) {
+            for (int i = node.start; i < node.end; ++i) {
+                int idx = indices[i];
+                const Vector3& p = (*points)[idx];
+                float distSq = (p - target).lengthSquared();
+                if (distSq < bestDistSq) {
+                    bestDistSq = distSq;
+                    bestIndex = idx;
+                }
+            }
+            return;
+        }
+
+        float diff = component(target, node.axis) - node.split;
+        int first = diff <= 0.0f ? node.left : node.right;
+        int second = diff <= 0.0f ? node.right : node.left;
+
+        if (first >= 0) {
+            nearestRecursive(first, target, bestDistSq, bestIndex);
+        }
+        if (second >= 0) {
+            const Node& other = nodes[second];
+            float bboxDist = distanceToBoundsSquared(target, other.minBounds, other.maxBounds);
+            if (bboxDist <= bestDistSq) {
+                nearestRecursive(second, target, bestDistSq, bestIndex);
+            }
+        }
+    }
+};
+
+InferenceEngine::InferenceEngine()
+    : endpointTree(new SimpleKdTree())
+    , intersectionTree(new SimpleKdTree())
+    , midpointTree(new SimpleKdTree())
+    , faceCenterTree(new SimpleKdTree())
+    , cachedStamp(0)
+    , dirty(true)
+{
+}
+
+void InferenceEngine::invalidate()
+{
+    dirty = true;
+}
+
+std::size_t InferenceEngine::computeStamp(const GeometryKernel& geometry) const
+{
+    std::size_t stamp = 1469598103934665603ull;
+    const auto& objects = geometry.getObjects();
+    for (const auto& obj : objects) {
+        const HalfEdgeMesh& mesh = obj->getMesh();
+        stamp ^= mesh.getVertices().size() + 0x9e3779b97f4a7c15ull + (stamp << 6) + (stamp >> 2);
+        stamp ^= mesh.getHalfEdges().size() + 0x517cc1b727220a95ull + (stamp << 6) + (stamp >> 2);
+        stamp ^= mesh.getFaces().size() + 0x27d4eb2f165667c5ull + (stamp << 6) + (stamp >> 2);
+    }
+    stamp ^= objects.size();
+    return stamp;
+}
+
+void InferenceEngine::ensureIndex(const GeometryKernel& geometry)
+{
+    std::size_t stamp = computeStamp(geometry);
+    if (!dirty && stamp == cachedStamp) {
+        return;
+    }
+    cachedStamp = stamp;
+    rebuild(geometry);
+    dirty = false;
+}
+
+void InferenceEngine::rebuild(const GeometryKernel& geometry)
+{
+    endpointPositions.clear();
+    intersectionPositions.clear();
+    midpointPositions.clear();
+    faceFeatures.clear();
+    edgeFeatures.clear();
+    faceCenterPositions.clear();
+
+    const auto& objects = geometry.getObjects();
+    for (const auto& obj : objects) {
+        const HalfEdgeMesh& mesh = obj->getMesh();
+        const auto& vertices = mesh.getVertices();
+        const auto& halfEdges = mesh.getHalfEdges();
+        const auto& faces = mesh.getFaces();
+
+        if (vertices.empty()) {
+            continue;
+        }
+
+        std::unordered_set<long long> edgeSeen;
+        std::vector<int> valence(vertices.size(), 0);
+        for (const auto& he : halfEdges) {
+            if (he.origin >= 0 && he.origin < static_cast<int>(valence.size())) {
+                ++valence[static_cast<size_t>(he.origin)];
+            }
+        }
+
+        for (const auto& v : vertices) {
+            endpointPositions.push_back(v.position);
+        }
+
+        for (size_t i = 0; i < vertices.size(); ++i) {
+            if (valence[i] >= 3) {
+                intersectionPositions.push_back(vertices[i].position);
+            }
+        }
+
+        for (const auto& he : halfEdges) {
+            if (he.origin < 0 || he.destination < 0) continue;
+            long long key = makeUndirectedKey(he.origin, he.destination);
+            if (!edgeSeen.insert(key).second) continue;
+            const Vector3& a = vertices[static_cast<size_t>(he.origin)].position;
+            const Vector3& b = vertices[static_cast<size_t>(he.destination)].position;
+            Vector3 midpoint = (a + b) * 0.5f;
+            midpointPositions.push_back(midpoint);
+            EdgeFeature feature;
+            feature.a = a;
+            feature.b = b;
+            feature.midpoint = midpoint;
+            feature.direction = normalizeOrZero(b - a);
+            edgeFeatures.push_back(feature);
+        }
+
+        for (const auto& face : faces) {
+            if (face.halfEdge < 0 || face.halfEdge >= static_cast<int>(halfEdges.size())) {
+                continue;
+            }
+            Vector3 centroid;
+            int count = 0;
+            float maxRadiusSq = 0.0f;
+            int heIndex = face.halfEdge;
+            std::unordered_set<int> visited;
+            while (visited.insert(heIndex).second) {
+                const auto& he = halfEdges[static_cast<size_t>(heIndex)];
+                if (he.origin < 0 || he.origin >= static_cast<int>(vertices.size())) {
+                    break;
+                }
+                const Vector3& pos = vertices[static_cast<size_t>(he.origin)].position;
+                centroid += pos;
+                ++count;
+                heIndex = he.next;
+                if (heIndex < 0 || heIndex >= static_cast<int>(halfEdges.size())) {
+                    break;
+                }
+                if (count > static_cast<int>(vertices.size()) * 2) {
+                    break; // guard
+                }
+            }
+            if (count <= 0) {
+                continue;
+            }
+            centroid = centroid / static_cast<float>(count);
+            heIndex = face.halfEdge;
+            visited.clear();
+            while (visited.insert(heIndex).second) {
+                const auto& he = halfEdges[static_cast<size_t>(heIndex)];
+                if (he.origin < 0 || he.origin >= static_cast<int>(vertices.size())) {
+                    break;
+                }
+                const Vector3& pos = vertices[static_cast<size_t>(he.origin)].position;
+                float dSq = (pos - centroid).lengthSquared();
+                if (dSq > maxRadiusSq) maxRadiusSq = dSq;
+                heIndex = he.next;
+                if (heIndex < 0 || heIndex >= static_cast<int>(halfEdges.size())) {
+                    break;
+                }
+                if (visited.size() > vertices.size() * 2) {
+                    break;
+                }
+            }
+            FaceFeature feature;
+            feature.center = centroid;
+            feature.normal = face.normal;
+            feature.radiusSquared = maxRadiusSq;
+            faceCenterPositions.push_back(centroid);
+            faceFeatures.push_back(feature);
+        }
+    }
+
+    endpointTree->build(&endpointPositions);
+    intersectionTree->build(&intersectionPositions);
+    midpointTree->build(&midpointPositions);
+    faceCenterTree->build(&faceCenterPositions);
+}
+
+InferenceResult InferenceEngine::query(const GeometryKernel& geometry, const InferenceContext& context)
+{
+    ensureIndex(geometry);
+
+    InferenceResult none;
+    if (context.maxSnapDistance <= 0.0f) {
+        return none;
+    }
+
+    PickRay ray = context.ray;
+    float dirLen = ray.direction.length();
+    if (dirLen <= kEpsilon) {
+        return none;
+    }
+    ray.direction = ray.direction / dirLen;
+
+    std::vector<InferenceResult> candidates;
+    candidates.reserve(12);
+
+    const std::array<float, 3> samples = { 1.0f, 5.0f, 20.0f };
+
+    auto trySample = [&](const std::vector<Vector3>& positions, const std::unique_ptr<SimpleKdTree>& tree,
+                         InferenceSnapType type, float threshold) {
+        if (!tree || positions.empty()) return;
+        for (float s : samples) {
+            Vector3 probe = ray.origin + ray.direction * s;
+            int idx = tree->nearest(probe, std::numeric_limits<float>::max());
+            if (idx < 0 || idx >= static_cast<int>(positions.size())) continue;
+            float t = 0.0f;
+            float distSq = distancePointToRaySquared(positions[static_cast<size_t>(idx)], ray, t);
+            if (distSq > threshold * threshold) continue;
+            InferenceResult res;
+            res.type = type;
+            res.position = positions[static_cast<size_t>(idx)];
+            res.distance = distSq;
+            candidates.push_back(res);
+        }
+    };
+
+    trySample(endpointPositions, endpointTree, InferenceSnapType::Endpoint, kPointSnapRadius);
+    trySample(intersectionPositions, intersectionTree, InferenceSnapType::Intersection, kPointSnapRadius);
+    trySample(midpointPositions, midpointTree, InferenceSnapType::Midpoint, kMidpointSnapRadius);
+    trySample(faceCenterPositions, faceCenterTree, InferenceSnapType::FaceCenter, kFaceSnapRadius);
+
+    // edge-based suggestions
+    for (const auto& edge : edgeFeatures) {
+        LineIntersection info = closestBetweenRayAndSegment(ray, edge.a, edge.b);
+        if (!info.valid) continue;
+        if (info.distanceSquared > kEdgeSnapRadius * kEdgeSnapRadius) continue;
+        InferenceResult res;
+        res.type = InferenceSnapType::OnEdge;
+        res.position = info.pointOnSegment;
+        res.direction = edge.direction;
+        res.reference = edge.a;
+        res.distance = info.distanceSquared;
+        candidates.push_back(res);
+
+        float alignment = std::fabs(edge.direction.dot(ray.direction));
+        if (alignment > kParallelThreshold) {
+            InferenceResult parallel = res;
+            parallel.type = InferenceSnapType::Parallel;
+            parallel.distance = info.distanceSquared * 1.05f;
+            candidates.push_back(parallel);
+        } else if (alignment < kPerpendicularThreshold) {
+            InferenceResult perp = res;
+            perp.type = InferenceSnapType::Perpendicular;
+            perp.distance = info.distanceSquared * 1.1f;
+            candidates.push_back(perp);
+        }
+    }
+
+    // face suggestions
+    for (size_t i = 0; i < faceFeatures.size(); ++i) {
+        const FaceFeature& face = faceFeatures[i];
+        float denom = face.normal.dot(ray.direction);
+        if (std::fabs(denom) < kEpsilon) {
+            continue;
+        }
+        float t = face.normal.dot(face.center - ray.origin) / denom;
+        if (t < 0.0f) continue;
+        Vector3 hit = ray.origin + ray.direction * t;
+        float distSq = (hit - face.center).lengthSquared();
+        float radiusSq = face.radiusSquared + std::max(0.01f, face.radiusSquared * 0.15f);
+        if (distSq <= radiusSq) {
+            InferenceResult res;
+            res.type = InferenceSnapType::OnFace;
+            res.position = hit;
+            res.direction = face.normal;
+            res.reference = face.center;
+            res.distance = distSq;
+            candidates.push_back(res);
+        }
+
+        float centerDist = distancePointToRaySquared(face.center, ray);
+        if (centerDist <= kFaceSnapRadius * kFaceSnapRadius) {
+            InferenceResult res;
+            res.type = InferenceSnapType::FaceCenter;
+            res.position = face.center;
+            res.direction = face.normal;
+            res.reference = face.center;
+            res.distance = centerDist;
+            candidates.push_back(res);
+        }
+    }
+
+    if (candidates.empty()) {
+        return none;
+    }
+
+    float bestScore = std::numeric_limits<float>::infinity();
+    InferenceResult best = none;
+    for (const auto& candidate : candidates) {
+        if (candidate.distance > context.maxSnapDistance * context.maxSnapDistance) {
+            continue;
+        }
+        float score = candidate.distance + biasForType(candidate.type);
+        if (score < bestScore) {
+            bestScore = score;
+            best = candidate;
+        }
+    }
+
+    return best;
+}
+
+const char* toString(InferenceSnapType type)
+{
+    switch (type) {
+    case InferenceSnapType::Endpoint: return "Endpoint";
+    case InferenceSnapType::Midpoint: return "Midpoint";
+    case InferenceSnapType::Intersection: return "Intersection";
+    case InferenceSnapType::FaceCenter: return "Face center";
+    case InferenceSnapType::OnEdge: return "On edge";
+    case InferenceSnapType::OnFace: return "On face";
+    case InferenceSnapType::Axis: return "Axis";
+    case InferenceSnapType::Parallel: return "Parallel";
+    case InferenceSnapType::Perpendicular: return "Perpendicular";
+    default: return "";
+    }
+}
+
+} // namespace Interaction

--- a/src/Interaction/InferenceEngine.h
+++ b/src/Interaction/InferenceEngine.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "../GeometryKernel/Vector3.h"
+
+class GeometryKernel;
+
+namespace Interaction {
+
+enum class InferenceSnapType {
+    None = 0,
+    Endpoint,
+    Midpoint,
+    Intersection,
+    FaceCenter,
+    OnEdge,
+    OnFace,
+    Axis,
+    Parallel,
+    Perpendicular
+};
+
+struct PickRay {
+    Vector3 origin;
+    Vector3 direction;
+};
+
+struct InferenceResult {
+    InferenceSnapType type = InferenceSnapType::None;
+    Vector3 position;
+    Vector3 direction;
+    Vector3 reference;
+    float distance = std::numeric_limits<float>::infinity();
+    bool locked = false;
+
+    bool isValid() const { return type != InferenceSnapType::None; }
+};
+
+struct InferenceContext {
+    PickRay ray;
+    float maxSnapDistance = 0.35f;
+    float pixelRadius = 6.0f;
+    Vector3 cameraTarget;
+};
+
+class InferenceEngine {
+public:
+    InferenceEngine();
+
+    void ensureIndex(const GeometryKernel& geometry);
+    InferenceResult query(const GeometryKernel& geometry, const InferenceContext& context);
+    void invalidate();
+
+private:
+    std::size_t computeStamp(const GeometryKernel& geometry) const;
+    void rebuild(const GeometryKernel& geometry);
+
+    struct FaceFeature;
+    struct EdgeFeature;
+
+    std::vector<Vector3> endpointPositions;
+    std::vector<Vector3> intersectionPositions;
+    std::vector<Vector3> midpointPositions;
+    std::vector<FaceFeature> faceFeatures;
+    std::vector<EdgeFeature> edgeFeatures;
+    std::vector<Vector3> faceCenterPositions;
+
+    class SimpleKdTree;
+    std::unique_ptr<SimpleKdTree> endpointTree;
+    std::unique_ptr<SimpleKdTree> intersectionTree;
+    std::unique_ptr<SimpleKdTree> midpointTree;
+    std::unique_ptr<SimpleKdTree> faceCenterTree;
+
+    std::size_t cachedStamp;
+    bool dirty;
+};
+
+const char* toString(InferenceSnapType type);
+
+} // namespace Interaction

--- a/src/Tools/SelectionTool.cpp
+++ b/src/Tools/SelectionTool.cpp
@@ -1,89 +1,113 @@
 #include "SelectionTool.h"
-#include <limits>
-#include <cmath>
+
+#include <QtCore/Qt>
+
 #include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "../GeometryKernel/Curve.h"
 #include "../GeometryKernel/Solid.h"
+#include "../GeometryKernel/HalfEdgeMesh.h"
 
-static bool rayGround(CameraController* cam,int sx,int sy,int viewportW,int viewportH,Vector3& out){
+namespace {
+bool rayToGround(CameraController* cam, int sx, int sy, int viewportW, int viewportH, Vector3& out)
+{
     if (viewportW <= 0 || viewportH <= 0) return false;
-    float cx,cy,cz; cam->getCameraPosition(cx,cy,cz);
-    float yaw=cam->getYaw(), pitch=cam->getPitch();
-    float ry=yaw*(float)M_PI/180.0f, rp=pitch*(float)M_PI/180.0f;
-    Vector3 f(-sinf(ry)*cosf(rp), -sinf(rp), -cosf(ry)*cosf(rp)); f=f.normalized();
-    Vector3 up(0,1,0); Vector3 r=f.cross(up).normalized(); up=r.cross(f).normalized();
-    const float fov=60.0f; float aspect = static_cast<float>(viewportW) / static_cast<float>(viewportH);
-    float nx=(2.0f*sx/viewportW)-1.0f, ny=1.0f-(2.0f*sy/viewportH); float th=tanf((fov*(float)M_PI/180.0f)/2.0f);
-    Vector3 dir=(f + r*(nx*th*aspect) + up*(ny*th)).normalized(); Vector3 o(cx,cy,cz);
-    if (fabs(dir.y) < 1e-6f) return false; float t=-o.y/dir.y; if (t<0) return false; out = o + dir*t; return true;
+    float cx, cy, cz; cam->getCameraPosition(cx, cy, cz);
+    float yaw = cam->getYaw();
+    float pitch = cam->getPitch();
+    float ry = yaw * static_cast<float>(M_PI) / 180.0f;
+    float rp = pitch * static_cast<float>(M_PI) / 180.0f;
+    Vector3 f(-sinf(ry) * cosf(rp), -sinf(rp), -cosf(ry) * cosf(rp)); f = f.normalized();
+    Vector3 up(0, 1, 0); Vector3 r = f.cross(up).normalized(); up = r.cross(f).normalized();
+    const float fov = 60.0f;
+    float aspect = static_cast<float>(viewportW) / static_cast<float>(viewportH);
+    float nx = (2.0f * sx / viewportW) - 1.0f;
+    float ny = 1.0f - (2.0f * sy / viewportH);
+    float th = tanf((fov * static_cast<float>(M_PI) / 180.0f) / 2.0f);
+    Vector3 dir = (f + r * (nx * th * aspect) + up * (ny * th)).normalized();
+    Vector3 origin(cx, cy, cz);
+    if (std::fabs(dir.y) < 1e-6f) return false;
+    float t = -origin.y / dir.y;
+    if (t < 0.0f) return false;
+    out = origin + dir * t;
+    return true;
+}
 }
 
-GeometryObject* SelectionTool::pickObjectAt(int sx,int sy){
-    // For now pick nearest curve vertex or any solid bounding cylinder by distance
-    Vector3 hit; if(!rayGround(camera,sx,sy,viewportWidth,viewportHeight,hit)) return nullptr;
-    float bestD = std::numeric_limits<float>::max();
-    GeometryObject* best=nullptr;
-    for (const auto& uptr : geometry->getObjects()) {
-        if (uptr->getType()==ObjectType::Curve) {
-            const Curve* c = static_cast<const Curve*>(uptr.get());
-            for (const auto& p : c->getPoints()) {
-                float dx=p.x-hit.x, dz=p.z-hit.z;
-                float d=dx*dx+dz*dz;
-                if (d<bestD) { bestD=d; best=uptr.get(); }
+GeometryObject* SelectionTool::pickObjectAt(const Vector3& worldPoint)
+{
+    float bestDistance = std::numeric_limits<float>::max();
+    GeometryObject* best = nullptr;
+
+    const float solidBias = 0.85f;
+
+    for (const auto& object : geometry->getObjects()) {
+        if (object->getType() == ObjectType::Curve) {
+            const Curve* curve = static_cast<const Curve*>(object.get());
+            const auto& loop = curve->getBoundaryLoop();
+            for (const auto& vertex : loop) {
+                float d = (vertex - worldPoint).lengthSquared();
+                if (d < bestDistance) {
+                    bestDistance = d;
+                    best = object.get();
+                }
             }
         } else {
-            const Solid* solid = static_cast<const Solid*>(uptr.get());
-            const auto& verts = solid->getVertices();
-            const auto& faces = solid->getFaces();
-            float minSolidDist = std::numeric_limits<float>::max();
-
-            for (const auto& face : faces) {
-                if (face.indices.empty()) continue;
-                Vector3 centroid;
-                for (int idx : face.indices) {
-                    const auto& v = verts[(size_t)idx];
-                    centroid = centroid + v;
-                }
-                float inv = 1.0f / static_cast<float>(face.indices.size());
-                centroid = centroid * inv;
-                float dx = centroid.x - hit.x;
-                float dz = centroid.z - hit.z;
-                float d = dx*dx + dz*dz;
-                if (d < minSolidDist) minSolidDist = d;
-            }
-
-            if (faces.empty()) {
-                for (const auto& v : verts) {
-                    float dx = v.x - hit.x;
-                    float dz = v.z - hit.z;
-                    float d = dx*dx + dz*dz;
-                    if (d < minSolidDist) minSolidDist = d;
+            const HalfEdgeMesh& mesh = object->getMesh();
+            float localBest = std::numeric_limits<float>::max();
+            for (const auto& vertex : mesh.getVertices()) {
+                float d = (vertex.position - worldPoint).lengthSquared();
+                if (d < localBest) {
+                    localBest = d;
                 }
             }
-
-            if (minSolidDist < std::numeric_limits<float>::max()) {
-                float biased = std::max(0.0f, minSolidDist - 1e-4f);
-                if (biased < bestD) { bestD = biased; best = uptr.get(); }
+            if (localBest < std::numeric_limits<float>::max()) {
+                float weighted = localBest * solidBias;
+                if (weighted < bestDistance) {
+                    bestDistance = weighted;
+                    best = object.get();
+                }
             }
         }
+    }
+
+    const float kSelectionRadius = 0.6f;
+    if (!best || bestDistance > kSelectionRadius * kSelectionRadius) {
+        return nullptr;
     }
     return best;
 }
 
-void SelectionTool::onMouseDown(int x,int y){
-    auto* obj = pickObjectAt(x,y);
-    if (obj) {
-        if (lastSelected) lastSelected->setSelected(false);
-        obj->setSelected(true);
-        lastSelected = obj;
+void SelectionTool::onMouseDown(int x, int y)
+{
+    Vector3 worldPoint;
+    const auto& snap = getInferenceResult();
+    if (snap.isValid()) {
+        worldPoint = snap.position;
+    } else if (!rayToGround(camera, x, y, viewportWidth, viewportHeight, worldPoint)) {
+        return;
+    }
+
+    if (GeometryObject* candidate = pickObjectAt(worldPoint)) {
+        if (lastSelected) {
+            lastSelected->setSelected(false);
+        }
+        candidate->setSelected(true);
+        lastSelected = candidate;
     }
 }
 
-void SelectionTool::onMouseUp(int,int){}
+void SelectionTool::onMouseUp(int, int)
+{
+}
 
-void SelectionTool::onKeyPress(char key){
-    if ((key==127 || key==8) && lastSelected) { // delete/backspace
+void SelectionTool::onKeyPress(int key)
+{
+    if ((key == Qt::Key_Delete || key == Qt::Key_Backspace) && lastSelected) {
         geometry->deleteObject(lastSelected);
         lastSelected = nullptr;
     }
 }
+

--- a/src/Tools/SelectionTool.h
+++ b/src/Tools/SelectionTool.h
@@ -7,8 +7,8 @@ public:
     const char* getName() const override { return "SelectionTool"; }
     void onMouseDown(int x, int y) override;
     void onMouseUp(int x, int y) override;
-    void onKeyPress(char key) override;
+    void onKeyPress(int key) override;
 private:
     GeometryObject* lastSelected = nullptr;
-    GeometryObject* pickObjectAt(int sx, int sy);
+    GeometryObject* pickObjectAt(const Vector3& worldPoint);
 };

--- a/src/Tools/SketchTool.cpp
+++ b/src/Tools/SketchTool.cpp
@@ -1,55 +1,122 @@
 #include "SketchTool.h"
+
 #include <cmath>
 
-static bool screenToGround(CameraController* cam,int x,int y,int viewportW,int viewportH,Vector3& out){
+#include "../Interaction/InferenceEngine.h"
+
+namespace {
+bool screenToGround(CameraController* cam, int x, int y, int viewportW, int viewportH, Vector3& out)
+{
     if (viewportW <= 0 || viewportH <= 0) return false;
-    float cx,cy,cz; cam->getCameraPosition(cx,cy,cz);
-    float yaw=cam->getYaw(), pitch=cam->getPitch();
-    float ry=yaw*(float)M_PI/180.0f, rp=pitch*(float)M_PI/180.0f;
-    Vector3 f(-sinf(ry)*cosf(rp), -sinf(rp), -cosf(ry)*cosf(rp)); f=f.normalized();
-    Vector3 up(0,1,0); Vector3 r=f.cross(up).normalized(); up=r.cross(f).normalized();
-    const float fov=60.0f; float aspect = static_cast<float>(viewportW) / static_cast<float>(viewportH);
-    float nx=(2.0f*x/viewportW)-1.0f, ny=1.0f-(2.0f*y/viewportH); float th=tanf((fov*(float)M_PI/180.0f)/2.0f);
-    Vector3 dir=(f + r*(nx*th*aspect) + up*(ny*th)).normalized(); Vector3 o(cx,cy,cz);
-    if (fabs(dir.y) < 1e-6f) return false; float t=-o.y/dir.y; if (t<0) return false; out = o + dir*t; return true;
+    float cx, cy, cz; cam->getCameraPosition(cx, cy, cz);
+    float yaw = cam->getYaw();
+    float pitch = cam->getPitch();
+    float ry = yaw * static_cast<float>(M_PI) / 180.0f;
+    float rp = pitch * static_cast<float>(M_PI) / 180.0f;
+    Vector3 f(-sinf(ry) * cosf(rp), -sinf(rp), -cosf(ry) * cosf(rp)); f = f.normalized();
+    Vector3 up(0, 1, 0);
+    Vector3 r = f.cross(up).normalized();
+    up = r.cross(f).normalized();
+    const float fov = 60.0f;
+    float aspect = static_cast<float>(viewportW) / static_cast<float>(viewportH);
+    float nx = (2.0f * x / viewportW) - 1.0f;
+    float ny = 1.0f - (2.0f * y / viewportH);
+    float th = tanf((fov * static_cast<float>(M_PI) / 180.0f) / 2.0f);
+    Vector3 dir = (f + r * (nx * th * aspect) + up * (ny * th)).normalized();
+    Vector3 origin(cx, cy, cz);
+    if (std::fabs(dir.y) < 1e-6f) return false;
+    float t = -origin.y / dir.y;
+    if (t < 0.0f) return false;
+    out = origin + dir * t;
+    return true;
 }
 
-static void axisSnap(Vector3& p){
-    // snap near integer grid and axis align (very lightweight)
-    const float grid=0.25f, eps=0.08f;
-    float gx = std::round(p.x/grid)*grid;
-    float gz = std::round(p.z/grid)*grid;
-    if (std::fabs(p.x-gx) < eps) p.x = gx;
-    if (std::fabs(p.z-gz) < eps) p.z = gz;
+void axisSnap(Vector3& point)
+{
+    const float grid = 0.25f;
+    const float eps = 0.08f;
+    float gx = std::round(point.x / grid) * grid;
+    float gz = std::round(point.z / grid) * grid;
+    if (std::fabs(point.x - gx) < eps) point.x = gx;
+    if (std::fabs(point.z - gz) < eps) point.z = gz;
+}
 }
 
-void SketchTool::onMouseDown(int x,int y){
-    Vector3 p; if(!screenToGround(camera,x,y,viewportWidth,viewportHeight,p)) return;
-    axisSnap(p);
+bool SketchTool::resolveFallback(int x, int y, Vector3& out) const
+{
+    Vector3 ground;
+    if (!screenToGround(camera, x, y, viewportWidth, viewportHeight, ground)) {
+        return false;
+    }
+    axisSnap(ground);
+    out = Vector3(ground.x, 0.0f, ground.z);
+    return true;
+}
+
+bool SketchTool::resolvePoint(int x, int y, Vector3& out) const
+{
+    const auto& snap = getInferenceResult();
+    if (snap.isValid()) {
+        out = snap.position;
+        return true;
+    }
+    return resolveFallback(x, y, out);
+}
+
+void SketchTool::onMouseDown(int x, int y)
+{
+    lastMouseX = x;
+    lastMouseY = y;
+    Vector3 point;
+    if (!resolvePoint(x, y, point)) {
+        previewValid = false;
+        return;
+    }
+
     if (!drawing) {
-        drawing = true; pts.clear(); pts.push_back(Vector3(p.x,0,p.z));
-    } else {
-        pts.push_back(Vector3(p.x,0,p.z));
+        drawing = true;
+        pts.clear();
     }
+
+    pts.push_back(point);
+    previewPoint = point;
+    previewValid = true;
 }
 
-void SketchTool::onMouseMove(int x,int y){
-    if (!drawing) return;
-    Vector3 p; if(!screenToGround(camera,x,y,viewportWidth,viewportHeight,p)) return;
-    axisSnap(p);
-    if (pts.empty()) pts.push_back(Vector3(p.x,0,p.z));
-    if (pts.size()==1) {
-        // preview second point
-    } else {
-        // live update last preview point
-        if (pts.size()>1) pts.back() = Vector3(p.x,0,p.z);
+void SketchTool::onMouseMove(int x, int y)
+{
+    lastMouseX = x;
+    lastMouseY = y;
+    Vector3 point;
+    if (!resolvePoint(x, y, point)) {
+        previewValid = false;
+        return;
     }
+    previewPoint = point;
+    previewValid = true;
 }
 
-void SketchTool::onMouseUp(int,int){
-    // if double-click–ish length >=2 finalize
-    if (drawing && pts.size()>=2) {
+void SketchTool::onMouseUp(int, int)
+{
+    if (drawing && pts.size() >= 2) {
         geometry->addCurve(pts);
-        drawing=false; pts.clear();
+        drawing = false;
+        pts.clear();
+        previewValid = false;
     }
 }
+
+void SketchTool::onInferenceResultChanged(const Interaction::InferenceResult& result)
+{
+    if (!drawing) {
+        if (result.isValid()) {
+            previewPoint = result.position;
+            previewValid = true;
+        } else if (resolveFallback(lastMouseX, lastMouseY, previewPoint)) {
+            previewValid = true;
+        } else {
+            previewValid = false;
+        }
+    }
+}
+

--- a/src/Tools/SketchTool.h
+++ b/src/Tools/SketchTool.h
@@ -9,6 +9,15 @@ public:
     void onMouseDown(int x,int y) override;
     void onMouseMove(int x,int y) override;
     void onMouseUp(int x,int y) override;
+    void onInferenceResultChanged(const Interaction::InferenceResult& result) override;
 private:
-    bool drawing=false; std::vector<Vector3> pts;
+    bool resolvePoint(int x, int y, Vector3& out) const;
+    bool resolveFallback(int x, int y, Vector3& out) const;
+
+    bool drawing=false;
+    std::vector<Vector3> pts;
+    Vector3 previewPoint;
+    bool previewValid = false;
+    int lastMouseX = 0;
+    int lastMouseY = 0;
 };

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../GeometryKernel/GeometryKernel.h"
 #include "../CameraController.h"
+#include "../Interaction/InferenceEngine.h"
 
 #include <algorithm>
 
@@ -11,7 +12,9 @@ public:
     virtual void onMouseDown(int,int) {}
     virtual void onMouseMove(int,int) {}
     virtual void onMouseUp(int,int) {}
-    virtual void onKeyPress(char) {}
+    virtual void onKeyPress(int) {}
+    virtual void onKeyRelease(int) {}
+    virtual void onInferenceResultChanged(const Interaction::InferenceResult&) {}
     virtual const char* getName() const = 0;
 
     void setViewportSize(int w, int h)
@@ -20,8 +23,18 @@ public:
         viewportHeight = std::max(1, h);
     }
 
+    const Interaction::InferenceResult& getInferenceResult() const { return currentInference; }
+    void setInferenceResult(const Interaction::InferenceResult& result)
+    {
+        currentInference = result;
+        onInferenceResultChanged(currentInference);
+    }
+
 protected:
     int viewportWidth = 1;
     int viewportHeight = 1;
     GeometryKernel* geometry; CameraController* camera;
+
+private:
+    Interaction::InferenceResult currentInference;
 };

--- a/src/Tools/ToolManager.cpp
+++ b/src/Tools/ToolManager.cpp
@@ -1,20 +1,49 @@
 #include "ToolManager.h"
 
-#include <algorithm>
-#include <cstring>
+#include <QtCore/Qt>
 
-ToolManager::ToolManager(GeometryKernel* g, CameraController* c)
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+using Interaction::InferenceContext;
+using Interaction::InferenceResult;
+using Interaction::InferenceSnapType;
+
+namespace {
+constexpr float kLockEpsilon = 1e-5f;
+
+Vector3 normalizeOrZero(const Vector3& value)
 {
-    tools.push_back(std::make_unique<SelectionTool>(g,c));
-    tools.push_back(std::make_unique<SketchTool>(g,c));
-    tools.push_back(std::make_unique<ExtrudeTool>(g,c));
-    propagateViewport();
-    active = tools.front().get();
+    float len = value.length();
+    if (len <= kLockEpsilon) {
+        return Vector3();
+    }
+    return value / len;
+}
 }
 
-void ToolManager::activateTool(const char* n){
-    for (auto& t : tools) {
-        if (std::strcmp(t->getName(), n) == 0) { active = t.get(); return; }
+ToolManager::ToolManager(GeometryKernel* g, CameraController* c)
+    : geometry(g)
+    , camera(c)
+{
+    tools.push_back(std::make_unique<SelectionTool>(g, c));
+    tools.push_back(std::make_unique<SketchTool>(g, c));
+    tools.push_back(std::make_unique<ExtrudeTool>(g, c));
+    active = tools.empty() ? nullptr : tools.front().get();
+    propagateViewport();
+    pushInferenceToActive();
+}
+
+void ToolManager::activateTool(const char* name)
+{
+    for (auto& tool : tools) {
+        if (std::strcmp(tool->getName(), name) == 0) {
+            active = tool.get();
+            pushInferenceToActive();
+            return;
+        }
     }
 }
 
@@ -25,9 +54,266 @@ void ToolManager::setViewportSize(int w, int h)
     propagateViewport();
 }
 
+void ToolManager::updateInference(const ToolInferenceUpdateRequest& request)
+{
+    if (!geometry) {
+        clearInference();
+        return;
+    }
+
+    if (!request.hasRay) {
+        currentInference = stickyActive ? stickyInference : InferenceResult{};
+        pushInferenceToActive();
+        return;
+    }
+
+    InferenceContext context;
+    context.ray = request.ray;
+    context.maxSnapDistance = 0.35f;
+    context.pixelRadius = request.pixelRadius;
+    if (camera) {
+        float tx, ty, tz;
+        camera->getTarget(tx, ty, tz);
+        context.cameraTarget = Vector3(tx, ty, tz);
+    }
+
+    currentInference = inferenceEngine.query(*geometry, context);
+    if (currentInference.isValid()) {
+        lastSnapPoint = currentInference.position;
+        lastSnapValid = true;
+        if (!axisAnchorValid) {
+            axisAnchor = currentInference.position;
+            axisAnchorValid = true;
+        }
+    }
+
+    updateStickyLock();
+    if (axisLocked) {
+        applyAxisLock(request);
+    } else if (currentInference.isValid()) {
+        axisAnchor = currentInference.position;
+        axisAnchorValid = true;
+    }
+
+    pushInferenceToActive();
+}
+
+void ToolManager::clearInference()
+{
+    currentInference = stickyActive ? stickyInference : InferenceResult{};
+    pushInferenceToActive();
+}
+
+void ToolManager::handleKeyPress(int key)
+{
+    if (key == Qt::Key_Shift) {
+        shiftPressed = true;
+        if (!stickyActive && currentInference.isValid()) {
+            stickyInference = currentInference;
+            stickyInference.locked = true;
+            stickyActive = true;
+        }
+        pushInferenceToActive();
+        return;
+    }
+
+    switch (key) {
+    case Qt::Key_Left:
+        setAxisLock(Vector3(-1.0f, 0.0f, 0.0f));
+        break;
+    case Qt::Key_Right:
+        setAxisLock(Vector3(1.0f, 0.0f, 0.0f));
+        break;
+    case Qt::Key_Up:
+        setAxisLock(Vector3(0.0f, 1.0f, 0.0f));
+        break;
+    case Qt::Key_Down:
+        setAxisLock(Vector3(0.0f, -1.0f, 0.0f));
+        break;
+    case Qt::Key_PageUp:
+        setAxisLock(Vector3(0.0f, 0.0f, 1.0f));
+        break;
+    case Qt::Key_PageDown:
+        setAxisLock(Vector3(0.0f, 0.0f, -1.0f));
+        break;
+    default:
+        if (active) {
+            active->onKeyPress(key);
+        }
+        break;
+    }
+}
+
+void ToolManager::handleKeyRelease(int key)
+{
+    if (key == Qt::Key_Shift) {
+        shiftPressed = false;
+        stickyActive = false;
+        stickyInference = InferenceResult{};
+        if (active) {
+            pushInferenceToActive();
+        }
+        return;
+    }
+
+    switch (key) {
+    case Qt::Key_Left:
+    case Qt::Key_Right:
+    case Qt::Key_Up:
+    case Qt::Key_Down:
+    case Qt::Key_PageUp:
+    case Qt::Key_PageDown:
+        axisLocked = false;
+        pushInferenceToActive();
+        break;
+    default:
+        if (active) {
+            active->onKeyRelease(key);
+        }
+        break;
+    }
+}
+
 void ToolManager::propagateViewport()
 {
     for (auto& tool : tools) {
         tool->setViewportSize(viewportWidth, viewportHeight);
     }
 }
+
+void ToolManager::pushInferenceToActive()
+{
+    if (active) {
+        active->setInferenceResult(currentInference);
+    }
+}
+
+void ToolManager::updateStickyLock()
+{
+    if (!shiftPressed) {
+        stickyActive = false;
+        stickyInference = InferenceResult{};
+        return;
+    }
+
+    if (!stickyActive && currentInference.isValid()) {
+        stickyInference = currentInference;
+        stickyInference.locked = true;
+        stickyActive = true;
+    }
+
+    if (stickyActive) {
+        currentInference = stickyInference;
+        currentInference.locked = true;
+    }
+}
+
+void ToolManager::applyAxisLock(const ToolInferenceUpdateRequest& request)
+{
+    if (!axisLocked || !request.hasRay) {
+        return;
+    }
+
+    Vector3 direction = normalizeOrZero(axisDirection);
+    if (direction.lengthSquared() <= kLockEpsilon) {
+        axisLocked = false;
+        return;
+    }
+
+    if (!axisAnchorValid) {
+        if (currentInference.isValid()) {
+            axisAnchor = currentInference.position;
+            axisAnchorValid = true;
+        } else if (stickyActive) {
+            axisAnchor = stickyInference.position;
+            axisAnchorValid = true;
+        } else if (lastSnapValid) {
+            axisAnchor = lastSnapPoint;
+            axisAnchorValid = true;
+        } else if (camera) {
+            float tx, ty, tz;
+            camera->getTarget(tx, ty, tz);
+            axisAnchor = Vector3(tx, ty, tz);
+            axisAnchorValid = true;
+        } else {
+            axisAnchor = Vector3();
+            axisAnchorValid = true;
+        }
+    }
+
+    Vector3 rayDir = normalizeOrZero(request.ray.direction);
+    if (rayDir.lengthSquared() <= kLockEpsilon) {
+        return;
+    }
+    Vector3 rayOrigin = request.ray.origin;
+
+    Vector3 w0 = rayOrigin - axisAnchor;
+    float a = rayDir.dot(rayDir);
+    float b = rayDir.dot(direction);
+    float c = direction.dot(direction);
+    float d = rayDir.dot(w0);
+    float e = direction.dot(w0);
+    float denom = a * c - b * b;
+    float s = 0.0f;
+    float t = 0.0f;
+    if (std::fabs(denom) > kLockEpsilon) {
+        s = (b * e - c * d) / denom;
+        t = (a * e - b * d) / denom;
+    } else {
+        t = -e / (c > kLockEpsilon ? c : 1.0f);
+    }
+    if (!stickyActive && t < 0.0f) {
+        t = 0.0f;
+    }
+    Vector3 axisPoint = axisAnchor + direction * t;
+    Vector3 rayPoint = rayOrigin + rayDir * s;
+    Vector3 delta = axisPoint - rayPoint;
+
+    InferenceResult axisResult;
+    axisResult.type = InferenceSnapType::Axis;
+    axisResult.position = axisPoint;
+    axisResult.direction = direction;
+    axisResult.reference = axisAnchor;
+    axisResult.distance = delta.lengthSquared();
+    axisResult.locked = stickyActive || axisLocked;
+    currentInference = axisResult;
+}
+
+void ToolManager::setAxisLock(const Vector3& direction)
+{
+    Vector3 norm = normalizeOrZero(direction);
+    if (norm.lengthSquared() <= kLockEpsilon) {
+        axisLocked = false;
+        return;
+    }
+
+    if (axisLocked) {
+        Vector3 diff = axisDirection - norm;
+        if (diff.lengthSquared() < 1e-4f) {
+            axisLocked = false;
+            return;
+        }
+    }
+
+    axisLocked = true;
+    axisDirection = norm;
+    if (currentInference.isValid()) {
+        axisAnchor = currentInference.position;
+        axisAnchorValid = true;
+    } else if (stickyActive) {
+        axisAnchor = stickyInference.position;
+        axisAnchorValid = true;
+    } else if (lastSnapValid) {
+        axisAnchor = lastSnapPoint;
+        axisAnchorValid = true;
+    } else if (camera) {
+        float tx, ty, tz;
+        camera->getTarget(tx, ty, tz);
+        axisAnchor = Vector3(tx, ty, tz);
+        axisAnchorValid = true;
+    } else {
+        axisAnchor = Vector3();
+        axisAnchorValid = true;
+    }
+}
+

--- a/src/Tools/ToolManager.h
+++ b/src/Tools/ToolManager.h
@@ -1,10 +1,20 @@
 #pragma once
-#include <vector>
+
 #include <memory>
+#include <vector>
+
 #include "Tool.h"
 #include "SelectionTool.h"
 #include "SketchTool.h"
 #include "ExtrudeTool.h"
+
+#include "../Interaction/InferenceEngine.h"
+
+struct ToolInferenceUpdateRequest {
+    bool hasRay = false;
+    Interaction::PickRay ray;
+    float pixelRadius = 6.0f;
+};
 
 class ToolManager {
 public:
@@ -12,11 +22,36 @@ public:
     Tool* getActiveTool() const { return active; }
     void activateTool(const char* name);
     void setViewportSize(int w, int h);
+
+    void updateInference(const ToolInferenceUpdateRequest& request);
+    void clearInference();
+    const Interaction::InferenceResult& getCurrentInference() const { return currentInference; }
+    void handleKeyPress(int key);
+    void handleKeyRelease(int key);
+
 private:
     void propagateViewport();
+    void pushInferenceToActive();
+    void updateStickyLock();
+    void applyAxisLock(const ToolInferenceUpdateRequest& request);
+    void setAxisLock(const Vector3& direction);
 
     std::vector<std::unique_ptr<Tool>> tools;
-    Tool* active=nullptr;
+    Tool* active = nullptr;
     int viewportWidth = 1;
     int viewportHeight = 1;
+    GeometryKernel* geometry = nullptr;
+    CameraController* camera = nullptr;
+    Interaction::InferenceEngine inferenceEngine;
+    Interaction::InferenceResult currentInference;
+    Interaction::InferenceResult stickyInference;
+    bool shiftPressed = false;
+    bool stickyActive = false;
+    bool axisLocked = false;
+    Vector3 axisDirection;
+    Vector3 axisAnchor;
+    bool axisAnchorValid = false;
+    Vector3 lastSnapPoint;
+    bool lastSnapValid = false;
 };
+

--- a/tests/manual/inference_shortcuts.md
+++ b/tests/manual/inference_shortcuts.md
@@ -1,0 +1,33 @@
+# Manual Test: Inference shortcuts and overlays
+
+## Purpose
+Verify that the inference engine surfaces snap suggestions, sticky locking, and axis locking. The test also confirms that overlay glyphs render while hovering geometry within 12 ms.
+
+## Preconditions
+* Build and launch FreeCrafter with the updated inference system.
+* Load or sketch a curve/solid so that vertices, edges, and faces are present.
+
+## Steps
+1. **Hover snapping**
+   1. Move the cursor over curve vertices, edge midpoints, and face centers.
+   2. Expect the inference glyph to appear in less than 12 ms with an identifying label (e.g., “Endpoint”, “Midpoint”).
+   3. Confirm that the dashed guide aligns with the inferred feature.
+2. **Sticky lock (Shift)**
+   1. Hover a desired snap point and press and hold **Shift**.
+   2. Move the cursor away; the glyph should remain “locked” and its label shows “(locked)”.
+   3. Release **Shift** and confirm the lock clears.
+3. **Axis lock (arrow keys)**
+   1. With a snap highlighted, press one of the arrow keys:
+      * **Left/Right** lock to the ±X axis.
+      * **Up/Down** lock to the ±Y axis.
+      * **PageUp/PageDown** lock to the ±Z axis.
+   2. Verify that the inference type switches to “Axis”, a dashed axis guide renders, and the snap point slides along that axis as the cursor moves.
+   3. Release the arrow key to clear the lock.
+4. **Tool integration**
+   1. With the Sketch tool active, click while a snap is shown and confirm the new vertex uses the snapped position.
+   2. With the Selection tool, click a snapped location and ensure the corresponding object becomes selected.
+
+## Expected Result
+* Inference glyphs update within a frame (<12 ms), including type-specific colors.
+* Sticky locks hold the snap until Shift is released.
+* Arrow keys toggle axis locks with dashed guides, and tools honor the locked snap positions.


### PR DESCRIPTION
## Summary
- introduce an inference engine module with kd-tree indexes for geometry snap hints
- update the tool manager and interactive tools to consume inference results with sticky and axis locks
- render inference overlays in the viewport and document the relevant manual shortcuts

## Testing
- cmake -S . -B build *(fails: Qt6 development files not available in the container)*