### PR TITLE
Implement shader renderer and render style switching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Widgets OpenGL OpenGLWidgets Svg)
 
-add_executable(${PROJECT_NAME}
-    src/main.cpp
+add_library(freecrafter_lib
     src/MainWindow.cpp
     src/GLViewport.cpp
+    src/Renderer.cpp
     src/CameraController.cpp
     src/HotkeyManager.cpp
     src/GeometryKernel/Curve.cpp
@@ -34,12 +34,24 @@ add_executable(${PROJECT_NAME}
     resources.qrc
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui)
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
+target_include_directories(freecrafter_lib PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui)
+target_link_libraries(freecrafter_lib PRIVATE Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE freecrafter_lib)
 # Installation
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin
         BUNDLE DESTINATION .)
+
+# Tests
+enable_testing()
+add_executable(test_render tests/test_render.cpp)
+target_link_libraries(test_render PRIVATE freecrafter_lib Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
+add_test(NAME render_regression COMMAND test_render)
 
 # Include Windows redistributable if present
 

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -9,6 +9,7 @@
 
 #include "GeometryKernel/GeometryKernel.h"
 #include "CameraController.h"
+#include "Renderer.h"
 
 class ToolManager;
 
@@ -19,6 +20,8 @@ public:
     explicit GLViewport(QWidget* parent = nullptr);
 
     void setToolManager(ToolManager* manager);
+    void setRenderStyle(Renderer::RenderStyle style);
+    Renderer::RenderStyle getRenderStyle() const { return renderStyle; }
     ToolManager* getToolManager() const { return toolManager; }
     GeometryKernel* getGeometry() { return &geometry; }
     CameraController* getCamera() { return &camera; }
@@ -65,4 +68,6 @@ private:
     double smoothedFrameMs = 0.0;
     int lastDrawCalls = 0;
     mutable int currentDrawCalls = 0;
+    Renderer renderer;
+    Renderer::RenderStyle renderStyle = Renderer::RenderStyle::ShadedWithEdges;
 };

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -15,6 +15,7 @@ class QActionGroup;
 class MeasurementWidget;
 
 #include "HotkeyManager.h"
+#include "Renderer.h"
 #include "Tools/ToolManager.h"
 
 class MainWindow : public QMainWindow {
@@ -64,6 +65,7 @@ private:
     void persistWindowState();
     void setActiveTool(QAction* action, const QString& toolId, const QString& hint);
     void updateThemeActionIcon();
+    void setRenderStyle(Renderer::RenderStyle style);
 
     void closeEvent(QCloseEvent* event) override;
 
@@ -80,6 +82,7 @@ private:
     QPointer<QDockWidget> rightDock;
     QPointer<QTabWidget> rightTabs;
     QPointer<QTabBar> documentTabs;
+    QPointer<QToolButton> renderStyleButton;
 
     QAction* actionNew = nullptr;
     QAction* actionOpen = nullptr;
@@ -113,8 +116,14 @@ private:
     QAction* measureAction = nullptr;
     QAction* gridAction = nullptr;
 
+    QActionGroup* renderStyleGroup = nullptr;
+    QAction* renderWireframeAction = nullptr;
+    QAction* renderShadedAction = nullptr;
+    QAction* renderShadedEdgesAction = nullptr;
+
     QActionGroup* toolActionGroup = nullptr;
 
     HotkeyManager hotkeys;
     bool darkTheme = true;
+    Renderer::RenderStyle renderStyleChoice = Renderer::RenderStyle::ShadedWithEdges;
 };

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,0 +1,281 @@
+#include "Renderer.h"
+
+#include <QOpenGLFunctions>
+#include <QOpenGLShader>
+#include <QtMath>
+#include <utility>
+
+namespace {
+const char* kLineVertexShader = R"(\
+#version 330 core
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec4 a_color;
+uniform mat4 u_mvp;
+out vec4 v_color;
+void main() {
+    v_color = a_color;
+    gl_Position = u_mvp * vec4(a_position, 1.0);
+}
+)";
+
+const char* kLineFragmentShader = R"(\
+#version 330 core
+in vec4 v_color;
+out vec4 fragColor;
+void main() {
+    fragColor = v_color;
+}
+)";
+
+const char* kTriangleVertexShader = R"(\
+#version 330 core
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec3 a_normal;
+layout(location = 2) in vec4 a_color;
+uniform mat4 u_mvp;
+uniform mat3 u_normalMatrix;
+uniform vec3 u_lightDir;
+out vec3 v_normal;
+out vec4 v_color;
+out float v_lighting;
+void main() {
+    vec3 normal = normalize(u_normalMatrix * a_normal);
+    v_normal = normal;
+    v_color = a_color;
+    float diffuse = max(dot(normal, normalize(u_lightDir)), 0.0);
+    v_lighting = diffuse;
+    gl_Position = u_mvp * vec4(a_position, 1.0);
+}
+)";
+
+const char* kTriangleFragmentShader = R"(\
+#version 330 core
+in vec3 v_normal;
+in vec4 v_color;
+in float v_lighting;
+out vec4 fragColor;
+void main() {
+    float ambient = 0.25;
+    float lighting = ambient + (1.0 - ambient) * clamp(v_lighting, 0.0, 1.0);
+    vec3 color = v_color.rgb * lighting;
+    fragColor = vec4(color, v_color.a);
+}
+)";
+}
+
+Renderer::Renderer()
+    : lineBuffer(QOpenGLBuffer::VertexBuffer)
+    , triangleBuffer(QOpenGLBuffer::VertexBuffer)
+{
+}
+
+void Renderer::initialize(QOpenGLFunctions* funcs)
+{
+    functions = funcs;
+    if (!lineBuffer.isCreated()) {
+        lineBuffer.create();
+    }
+    if (!triangleBuffer.isCreated()) {
+        triangleBuffer.create();
+    }
+    if (!lineVao.isCreated()) {
+        lineVao.create();
+    }
+    if (!triangleVao.isCreated()) {
+        triangleVao.create();
+    }
+    programsReady = false;
+}
+
+void Renderer::beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, RenderStyle style)
+{
+    ensurePrograms();
+    lineBatches.clear();
+    triangleVertices.clear();
+    currentStyle = style;
+    mvp = projection * view;
+    normalMatrix = view.normalMatrix();
+    QVector3D lightWorld(0.3f, 0.8f, 0.6f);
+    QVector3D transformed = view.mapVector(lightWorld);
+    if (!transformed.isNull()) {
+        lightDir = transformed.normalized();
+    } else {
+        lightDir = QVector3D(0.0f, 1.0f, 0.0f);
+    }
+}
+
+Renderer::LineBatch& Renderer::fetchBatch(float width, bool depthTest, bool blend, LineCategory category)
+{
+    for (auto& batch : lineBatches) {
+        if (qFuzzyCompare(batch.config.width, width)
+            && batch.config.depthTest == depthTest
+            && batch.config.blend == blend
+            && batch.config.category == category) {
+            return batch;
+        }
+    }
+    LineBatch batch;
+    batch.config.width = width;
+    batch.config.depthTest = depthTest;
+    batch.config.blend = blend;
+    batch.config.category = category;
+    lineBatches.push_back(std::move(batch));
+    return lineBatches.back();
+}
+
+void Renderer::addLineSegments(const std::vector<QVector3D>& segments,
+                               const QVector4D& color,
+                               float width,
+                               bool depthTest,
+                               bool blend,
+                               LineCategory category)
+{
+    if (segments.size() < 2) {
+        return;
+    }
+    auto& batch = fetchBatch(width, depthTest, blend, category);
+    batch.vertices.reserve(batch.vertices.size() + segments.size());
+    for (size_t i = 1; i < segments.size(); i += 2) {
+        const QVector3D& a = segments[i - 1];
+        const QVector3D& b = segments[i];
+        batch.vertices.push_back({ a, color });
+        batch.vertices.push_back({ b, color });
+    }
+}
+
+void Renderer::addLineStrip(const std::vector<QVector3D>& points,
+                            const QVector4D& color,
+                            float width,
+                            bool closed,
+                            bool depthTest,
+                            bool blend,
+                            LineCategory category)
+{
+    if (points.size() < 2) {
+        return;
+    }
+    auto& batch = fetchBatch(width, depthTest, blend, category);
+    batch.vertices.reserve(batch.vertices.size() + (points.size() - 1 + (closed ? 1 : 0)) * 2);
+    for (size_t i = 1; i < points.size(); ++i) {
+        batch.vertices.push_back({ points[i - 1], color });
+        batch.vertices.push_back({ points[i], color });
+    }
+    if (closed) {
+        batch.vertices.push_back({ points.back(), color });
+        batch.vertices.push_back({ points.front(), color });
+    }
+}
+
+void Renderer::addTriangle(const QVector3D& a,
+                           const QVector3D& b,
+                           const QVector3D& c,
+                           const QVector3D& normal,
+                           const QVector4D& color)
+{
+    triangleVertices.push_back({ a, normal, color });
+    triangleVertices.push_back({ b, normal, color });
+    triangleVertices.push_back({ c, normal, color });
+}
+
+void Renderer::ensurePrograms()
+{
+    if (programsReady) {
+        return;
+    }
+
+    if (!lineProgram.isLinked()) {
+        lineProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, kLineVertexShader);
+        lineProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, kLineFragmentShader);
+        lineProgram.link();
+    }
+
+    if (!triangleProgram.isLinked()) {
+        triangleProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, kTriangleVertexShader);
+        triangleProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, kTriangleFragmentShader);
+        triangleProgram.link();
+    }
+
+    programsReady = lineProgram.isLinked() && triangleProgram.isLinked();
+}
+
+void Renderer::ensureLineState(const LineBatch& batch)
+{
+    QOpenGLVertexArrayObject::Binder binder(&lineVao);
+    lineBuffer.bind();
+    lineBuffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    lineBuffer.allocate(batch.vertices.data(), static_cast<int>(batch.vertices.size() * sizeof(LineVertex)));
+
+    lineProgram.bind();
+    lineProgram.setUniformValue("u_mvp", mvp);
+    lineProgram.enableAttributeArray(0);
+    lineProgram.setAttributeBuffer(0, GL_FLOAT, offsetof(LineVertex, position), 3, sizeof(LineVertex));
+    lineProgram.enableAttributeArray(1);
+    lineProgram.setAttributeBuffer(1, GL_FLOAT, offsetof(LineVertex, color), 4, sizeof(LineVertex));
+
+    if (batch.config.depthTest) {
+        functions->glEnable(GL_DEPTH_TEST);
+    } else {
+        functions->glDisable(GL_DEPTH_TEST);
+    }
+    if (batch.config.blend) {
+        functions->glEnable(GL_BLEND);
+        functions->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    } else {
+        functions->glDisable(GL_BLEND);
+    }
+    functions->glLineWidth(batch.config.width);
+}
+
+void Renderer::ensureTriangleState()
+{
+    QOpenGLVertexArrayObject::Binder binder(&triangleVao);
+    triangleBuffer.bind();
+    triangleBuffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    triangleBuffer.allocate(triangleVertices.data(), static_cast<int>(triangleVertices.size() * sizeof(TriangleVertex)));
+
+    triangleProgram.bind();
+    triangleProgram.setUniformValue("u_mvp", mvp);
+    triangleProgram.setUniformValue("u_normalMatrix", normalMatrix);
+    triangleProgram.setUniformValue("u_lightDir", lightDir);
+    triangleProgram.enableAttributeArray(0);
+    triangleProgram.setAttributeBuffer(0, GL_FLOAT, offsetof(TriangleVertex, position), 3, sizeof(TriangleVertex));
+    triangleProgram.enableAttributeArray(1);
+    triangleProgram.setAttributeBuffer(1, GL_FLOAT, offsetof(TriangleVertex, normal), 3, sizeof(TriangleVertex));
+    triangleProgram.enableAttributeArray(2);
+    triangleProgram.setAttributeBuffer(2, GL_FLOAT, offsetof(TriangleVertex, color), 4, sizeof(TriangleVertex));
+
+    functions->glDisable(GL_BLEND);
+    functions->glEnable(GL_DEPTH_TEST);
+    functions->glLineWidth(1.0f);
+}
+
+int Renderer::flush()
+{
+    ensurePrograms();
+    int draws = 0;
+
+    if (currentStyle != RenderStyle::Wireframe && !triangleVertices.empty()) {
+        ensureTriangleState();
+        functions->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(triangleVertices.size()));
+        ++draws;
+    }
+
+    for (const auto& batch : lineBatches) {
+        if (batch.vertices.empty()) {
+            continue;
+        }
+        if (batch.config.category == LineCategory::Edge && currentStyle == RenderStyle::Shaded) {
+            continue;
+        }
+        ensureLineState(batch);
+        functions->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(batch.vertices.size()));
+        ++draws;
+    }
+
+    functions->glDisable(GL_BLEND);
+    functions->glEnable(GL_DEPTH_TEST);
+    functions->glLineWidth(1.0f);
+
+    return draws;
+}
+

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <QMatrix3x3>
+#include <QMatrix4x4>
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
+#include <QVector3D>
+#include <QVector4D>
+#include <vector>
+
+class QOpenGLFunctions;
+
+class Renderer
+{
+public:
+    enum class RenderStyle {
+        Wireframe,
+        Shaded,
+        ShadedWithEdges
+    };
+
+    enum class LineCategory {
+        Generic,
+        Edge
+    };
+
+    Renderer();
+
+    void initialize(QOpenGLFunctions* functions);
+    void beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, RenderStyle style);
+
+    void addLineSegments(const std::vector<QVector3D>& segments,
+                         const QVector4D& color,
+                         float width,
+                         bool depthTest,
+                         bool blend,
+                         LineCategory category = LineCategory::Generic);
+
+    void addLineStrip(const std::vector<QVector3D>& points,
+                      const QVector4D& color,
+                      float width,
+                      bool closed,
+                      bool depthTest,
+                      bool blend,
+                      LineCategory category = LineCategory::Generic);
+
+    void addTriangle(const QVector3D& a,
+                     const QVector3D& b,
+                     const QVector3D& c,
+                     const QVector3D& normal,
+                     const QVector4D& color);
+
+    int flush();
+
+private:
+    struct LineVertex {
+        QVector3D position;
+        QVector4D color;
+    };
+
+    struct TriangleVertex {
+        QVector3D position;
+        QVector3D normal;
+        QVector4D color;
+    };
+
+    struct LineBatchConfig {
+        float width = 1.0f;
+        bool depthTest = true;
+        bool blend = false;
+        LineCategory category = LineCategory::Generic;
+    };
+
+    struct LineBatch {
+        LineBatchConfig config;
+        std::vector<LineVertex> vertices;
+    };
+
+    LineBatch& fetchBatch(float width, bool depthTest, bool blend, LineCategory category);
+
+    void ensurePrograms();
+    void ensureLineState(const LineBatch& batch);
+    void ensureTriangleState();
+
+    QOpenGLFunctions* functions = nullptr;
+    QOpenGLShaderProgram lineProgram;
+    QOpenGLShaderProgram triangleProgram;
+    QOpenGLBuffer lineBuffer;
+    QOpenGLBuffer triangleBuffer;
+    QOpenGLVertexArrayObject lineVao;
+    QOpenGLVertexArrayObject triangleVao;
+
+    std::vector<LineBatch> lineBatches;
+    std::vector<TriangleVertex> triangleVertices;
+
+    QMatrix4x4 mvp;
+    QMatrix3x3 normalMatrix;
+    QVector3D lightDir;
+    RenderStyle currentStyle = RenderStyle::ShadedWithEdges;
+    bool programsReady = false;
+};
+

--- a/tests/manual/rendering.md
+++ b/tests/manual/rendering.md
@@ -1,0 +1,7 @@
+# Rendering Smoke Test
+
+1. Launch **FreeCrafter** and load the default empty document.
+2. Confirm that the toolbar now shows a **Style** drop-down. Switch between **Wireframe**, **Shaded**, and **Shaded+Edges** and verify that the viewport updates instantly.
+3. Orbit the camera around the default axes and ensure that wireframe mode hides face shading, shaded mode hides edge overlays, and shaded+edges renders both fills and silhouettes.
+4. Close the application while a non-default style is active, relaunch, and verify that the selected style is restored automatically.
+5. Extrude a simple rectangle and confirm that ghost previews and inference overlays respect the active render style (e.g., shaded mode still shows preview curves with transparency).

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -1,0 +1,133 @@
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QImage>
+#include <QColor>
+#include <QByteArray>
+
+#include "GLViewport.h"
+#include "Renderer.h"
+#include "GeometryKernel/GeometryKernel.h"
+#include "GeometryKernel/Vector3.h"
+
+#include <vector>
+#include <cmath>
+
+namespace {
+
+struct CaptureMetrics {
+    int totalPixels = 0;
+    int nonBackground = 0;
+    double averageIntensity = 0.0;
+    double nonBackgroundIntensity = 0.0;
+    bool valid = false;
+};
+
+CaptureMetrics captureMetrics(GLViewport& viewport, QApplication& app)
+{
+    CaptureMetrics metrics;
+    viewport.update();
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 200) {
+        app.processEvents(QEventLoop::AllEvents, 16);
+    }
+    QImage image = viewport.grabFramebuffer();
+    if (image.isNull()) {
+        return metrics;
+    }
+    metrics.totalPixels = image.width() * image.height();
+    if (metrics.totalPixels <= 0) {
+        return metrics;
+    }
+
+    const int background = static_cast<int>(0.95f * 255.0f);
+    const int threshold = 8;
+    double sumIntensity = 0.0;
+    double sumNonBackground = 0.0;
+    int nonBackgroundCount = 0;
+
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            const QColor color = image.pixelColor(x, y);
+            double intensity = (color.red() + color.green() + color.blue()) / (3.0 * 255.0);
+            sumIntensity += intensity;
+            if (std::abs(color.red() - background) > threshold ||
+                std::abs(color.green() - background) > threshold ||
+                std::abs(color.blue() - background) > threshold) {
+                ++nonBackgroundCount;
+                sumNonBackground += intensity;
+            }
+        }
+    }
+
+    metrics.nonBackground = nonBackgroundCount;
+    metrics.averageIntensity = sumIntensity / metrics.totalPixels;
+    metrics.nonBackgroundIntensity = nonBackgroundCount > 0 ? (sumNonBackground / nonBackgroundCount) : 0.0;
+    metrics.valid = true;
+    return metrics;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+    QApplication app(argc, argv);
+
+    GLViewport viewport;
+    viewport.resize(400, 300);
+    viewport.show();
+
+    GeometryKernel* geometry = viewport.getGeometry();
+    std::vector<Vector3> base{
+        {-0.5f, 0.0f, -0.5f},
+        {0.5f, 0.0f, -0.5f},
+        {0.5f, 0.0f, 0.5f},
+        {-0.5f, 0.0f, 0.5f},
+        {-0.5f, 0.0f, -0.5f}
+    };
+    GeometryObject* curveObj = geometry->addCurve(base);
+    geometry->extrudeCurve(curveObj, 0.6f);
+
+    viewport.setRenderStyle(Renderer::RenderStyle::Wireframe);
+    CaptureMetrics wire = captureMetrics(viewport, app);
+    if (!wire.valid || wire.nonBackground <= 0) {
+        return 1;
+    }
+
+    viewport.setRenderStyle(Renderer::RenderStyle::Shaded);
+    CaptureMetrics shaded = captureMetrics(viewport, app);
+    if (!shaded.valid) {
+        return 2;
+    }
+
+    viewport.setRenderStyle(Renderer::RenderStyle::ShadedWithEdges);
+    CaptureMetrics shadedEdges = captureMetrics(viewport, app);
+    if (!shadedEdges.valid) {
+        return 3;
+    }
+
+    const double wireCoverage = static_cast<double>(wire.nonBackground) / wire.totalPixels;
+    const double shadedCoverage = static_cast<double>(shaded.nonBackground) / shaded.totalPixels;
+    const double edgeCoverage = static_cast<double>(shadedEdges.nonBackground) / shadedEdges.totalPixels;
+
+    if (shadedCoverage <= wireCoverage * 3.0) {
+        return 4;
+    }
+    if (edgeCoverage < shadedCoverage) {
+        return 5;
+    }
+    if ((shadedEdges.nonBackground - shaded.nonBackground) < 150) {
+        return 6;
+    }
+    if (shaded.nonBackgroundIntensity >= 0.85) {
+        return 7;
+    }
+    if (wire.nonBackgroundIntensity >= 0.5) {
+        return 8;
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable Renderer helper that batches triangles and lines with shader programs
- migrate GLViewport drawing to use the renderer and expose render style toggles in the UI
- restructure the build to share a library, add a render regression check, and document manual smoke tests

## Testing
- not run (Qt 6 SDK unavailable in container)