### PR TITLE
Add camera navigation tools and navigation preferences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ add_library(freecrafter_lib
     src/GLViewport.cpp
     src/Renderer.cpp
     src/CameraController.cpp
+    src/CameraNavigation.cpp
     src/HotkeyManager.cpp
+    src/NavigationPreferences.cpp
     src/GeometryKernel/Curve.cpp
     src/GeometryKernel/HalfEdgeMesh.cpp
     src/GeometryKernel/MeshUtils.cpp
@@ -28,6 +30,9 @@ add_library(freecrafter_lib
     src/Tools/RotateTool.cpp
     src/Tools/ScaleTool.cpp
     src/Tools/ExtrudeTool.cpp
+    src/Tools/OrbitTool.cpp
+    src/Tools/PanTool.cpp
+    src/Tools/ZoomTool.cpp
     src/Tools/ToolManager.cpp
     src/Interaction/InferenceEngine.cpp
     src/ui/MeasurementWidget.cpp

--- a/resources.qrc
+++ b/resources.qrc
@@ -56,5 +56,6 @@
   </qresource>
   <qresource prefix="/config">
     <file>resources/config/hotkeys_default.json</file>
+    <file>resources/config/navigation_default.json</file>
   </qresource>
 </RCC>

--- a/resources/config/navigation_default.json
+++ b/resources/config/navigation_default.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "defaultScheme": "sketchup",
+  "schemes": [
+    {
+      "id": "sketchup",
+      "label": "SketchUp",
+      "description": "Middle button orbits, Shift+middle pans, and zoom focuses on the cursor.",
+      "wheelTool": "ZoomTool",
+      "zoomToCursor": true,
+      "invertWheel": false,
+      "wheelStep": 1.0,
+      "dragBindings": [
+        { "button": "Middle", "tool": "OrbitTool", "temporary": true },
+        { "button": "Middle", "modifiers": ["Shift"], "tool": "PanTool", "temporary": true }
+      ]
+    },
+    {
+      "id": "dsm",
+      "label": "DesignSpark",
+      "description": "Right button orbits, middle button pans, zoom follows the cursor similar to DesignSpark Mechanical.",
+      "wheelTool": "ZoomTool",
+      "zoomToCursor": true,
+      "invertWheel": false,
+      "wheelStep": 1.0,
+      "dragBindings": [
+        { "button": "Right", "tool": "OrbitTool", "temporary": true },
+        { "button": "Middle", "tool": "PanTool", "temporary": true }
+      ]
+    }
+  ]
+}

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -84,8 +84,8 @@ void CameraController::panCamera(float dx, float dy) {
 
 void CameraController::zoomCamera(float delta) {
     const float zoomSpeed = 1.1f;
-    if (delta > 0) distance /= zoomSpeed;
-    else distance *= zoomSpeed;
+    float factor = std::pow(zoomSpeed, -delta);
+    distance *= factor;
     if (distance < 1.0f) distance = 1.0f;
     if (distance > 2000.0f) distance = 2000.0f;
 }

--- a/src/CameraNavigation.cpp
+++ b/src/CameraNavigation.cpp
@@ -1,0 +1,160 @@
+#include "CameraNavigation.h"
+
+#include "CameraController.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+constexpr float kFovDegrees = 60.0f;
+constexpr float kEpsilon = 1e-6f;
+
+Vector3 computeForward(const CameraController& camera)
+{
+    float cx, cy, cz;
+    camera.getCameraPosition(cx, cy, cz);
+    float tx, ty, tz;
+    camera.getTarget(tx, ty, tz);
+    Vector3 cameraPos(cx, cy, cz);
+    Vector3 target(tx, ty, tz);
+    Vector3 forward = target - cameraPos;
+    if (forward.lengthSquared() < kEpsilon)
+        return Vector3(0.0f, 0.0f, -1.0f);
+    return forward / forward.length();
+}
+
+bool computeRay(const CameraController& camera, int pixelX, int pixelY, int viewportWidth, int viewportHeight,
+                Vector3& origin, Vector3& direction)
+{
+    if (viewportWidth <= 0 || viewportHeight <= 0)
+        return false;
+
+    float cx, cy, cz;
+    camera.getCameraPosition(cx, cy, cz);
+    float tx, ty, tz;
+    camera.getTarget(tx, ty, tz);
+
+    origin = Vector3(cx, cy, cz);
+    Vector3 forward = computeForward(camera);
+    Vector3 up(0.0f, 1.0f, 0.0f);
+    Vector3 right = forward.cross(up);
+    if (right.lengthSquared() < kEpsilon) {
+        up = Vector3(0.0f, 0.0f, 1.0f);
+        right = forward.cross(up);
+    }
+    right = right.lengthSquared() < kEpsilon ? Vector3(1.0f, 0.0f, 0.0f) : right.normalized();
+    up = right.cross(forward).normalized();
+
+    float nx = (2.0f * static_cast<float>(pixelX) / static_cast<float>(viewportWidth)) - 1.0f;
+    float ny = 1.0f - (2.0f * static_cast<float>(pixelY) / static_cast<float>(viewportHeight));
+
+    const float fovRadians = kFovDegrees * static_cast<float>(M_PI) / 180.0f;
+    const float tanHalfFov = std::tan(fovRadians * 0.5f);
+    const float aspect = static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight);
+
+    direction = (forward + right * (nx * tanHalfFov * aspect) + up * (ny * tanHalfFov));
+    if (direction.lengthSquared() < kEpsilon)
+        return false;
+    direction = direction.normalized();
+    return true;
+}
+
+float computeNewDistance(CameraController& camera, float delta)
+{
+    const float zoomSpeed = 1.1f;
+    float factor = std::pow(zoomSpeed, -delta);
+    float distance = camera.getDistance();
+    distance = std::clamp(distance * factor, 1.0f, 2000.0f);
+    camera.setDistance(distance);
+    return distance;
+}
+
+Vector3 offsetFromAngles(float distance, float yawDegrees, float pitchDegrees)
+{
+    const float yawRadians = yawDegrees * static_cast<float>(M_PI) / 180.0f;
+    const float pitchRadians = pitchDegrees * static_cast<float>(M_PI) / 180.0f;
+    return Vector3(std::sin(yawRadians) * std::cos(pitchRadians) * distance, std::sin(pitchRadians) * distance,
+                   std::cos(yawRadians) * std::cos(pitchRadians) * distance);
+}
+
+} // namespace
+
+namespace CameraNavigation {
+
+bool zoomAboutCursor(CameraController& camera, float delta, int pixelX, int pixelY, int viewportWidth, int viewportHeight,
+                     bool zoomToCursor)
+{
+    if (std::fabs(delta) < 1e-6f)
+        return false;
+
+    float cx, cy, cz;
+    camera.getCameraPosition(cx, cy, cz);
+    float tx, ty, tz;
+    camera.getTarget(tx, ty, tz);
+
+    Vector3 cameraPos(cx, cy, cz);
+    Vector3 target(tx, ty, tz);
+    Vector3 focus = target;
+
+    if (zoomToCursor) {
+        Vector3 origin;
+        Vector3 direction;
+        if (computeRay(camera, pixelX, pixelY, viewportWidth, viewportHeight, origin, direction)) {
+            Vector3 planeNormal = target - cameraPos;
+            float denom = planeNormal.dot(direction);
+            if (std::fabs(denom) > kEpsilon) {
+                float t = planeNormal.dot(target - origin) / denom;
+                if (t > 0.0f)
+                    focus = origin + direction * t;
+            }
+        }
+    }
+
+    Vector3 focusToCamera = cameraPos - focus;
+    if (focusToCamera.lengthSquared() < kEpsilon)
+        focusToCamera = cameraPos - target;
+
+    if (focusToCamera.lengthSquared() < kEpsilon)
+        focusToCamera = Vector3(0.0f, 0.0f, 1.0f);
+
+    float previousDistance = camera.getDistance();
+    float newDistance = computeNewDistance(camera, delta);
+    if (std::fabs(previousDistance) < kEpsilon)
+        previousDistance = 1.0f;
+    float scale = newDistance / previousDistance;
+    Vector3 newCameraPos = focus + focusToCamera * scale;
+
+    Vector3 offset = offsetFromAngles(newDistance, camera.getYaw(), camera.getPitch());
+    Vector3 newTarget = newCameraPos - offset;
+    camera.setTarget(newTarget.x, newTarget.y, newTarget.z);
+    return true;
+}
+
+bool frameBounds(CameraController& camera, const Vector3& minBounds, const Vector3& maxBounds, int viewportWidth,
+                 int viewportHeight)
+{
+    Vector3 center = (minBounds + maxBounds) * 0.5f;
+    Vector3 extents = (maxBounds - minBounds) * 0.5f;
+    float radius = extents.length();
+    float largestComponent = std::max({ std::fabs(extents.x), std::fabs(extents.y), std::fabs(extents.z) });
+    radius = std::max(radius, largestComponent);
+    if (radius < 1e-3f)
+        radius = std::max(largestComponent, 0.5f);
+
+    const float fovRadians = kFovDegrees * static_cast<float>(M_PI) / 180.0f;
+    const float halfFov = fovRadians * 0.5f;
+    float aspect = (viewportWidth > 0 && viewportHeight > 0) ? static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight)
+                                                            : 1.0f;
+    float horizontalHalfFov = std::atan(std::tan(halfFov) * aspect);
+
+    float minDistanceVertical = radius / std::max(std::tan(halfFov), 1e-3f);
+    float minDistanceHorizontal = radius / std::max(std::tan(horizontalHalfFov), 1e-3f);
+    float distance = std::max({ minDistanceVertical, minDistanceHorizontal, radius + 0.5f, 1.0f });
+    distance *= 1.2f;
+
+    camera.setTarget(center.x, center.y, center.z);
+    camera.setDistance(distance);
+    return true;
+}
+
+} // namespace CameraNavigation

--- a/src/CameraNavigation.h
+++ b/src/CameraNavigation.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "GeometryKernel/Vector3.h"
+
+class CameraController;
+
+namespace CameraNavigation {
+
+bool zoomAboutCursor(CameraController& camera, float delta, int pixelX, int pixelY, int viewportWidth, int viewportHeight,
+                     bool zoomToCursor);
+
+bool frameBounds(CameraController& camera, const Vector3& minBounds, const Vector3& maxBounds, int viewportWidth,
+                 int viewportHeight);
+
+}

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -10,8 +10,12 @@
 #include "GeometryKernel/GeometryKernel.h"
 #include "CameraController.h"
 #include "Renderer.h"
+#include "NavigationConfig.h"
+
+#include <optional>
 
 class ToolManager;
+class NavigationPreferences;
 
 class GLViewport : public QOpenGLWidget, protected QOpenGLFunctions
 {
@@ -20,6 +24,7 @@ public:
     explicit GLViewport(QWidget* parent = nullptr);
 
     void setToolManager(ToolManager* manager);
+    void setNavigationPreferences(NavigationPreferences* prefs);
     void setRenderStyle(Renderer::RenderStyle style);
     Renderer::RenderStyle getRenderStyle() const { return renderStyle; }
     ToolManager* getToolManager() const { return toolManager; }
@@ -61,13 +66,14 @@ private:
     GeometryKernel geometry;
     CameraController camera;
     ToolManager* toolManager = nullptr;
+    NavigationPreferences* navigationPrefs = nullptr;
+    NavigationConfig navigationConfig;
 
     QPoint lastMouse;
     QPoint lastDeviceMouse;
     bool hasDeviceMouse = false;
-    enum class NavigationDragMode { None, Orbit, Pan };
-    NavigationDragMode navigationMode = NavigationDragMode::None;
     Qt::MouseButton navigationButton = Qt::NoButton;
+    std::optional<NavigationConfig::DragBinding> activeNavigationBinding;
 
     QTimer repaintTimer;
     QElapsedTimer frameTimer;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -13,6 +13,7 @@ class QTabWidget;
 class QTabBar;
 class QActionGroup;
 class MeasurementWidget;
+class NavigationPreferences;
 
 #include "HotkeyManager.h"
 #include "Renderer.h"
@@ -65,6 +66,8 @@ private:
     void restoreWindowState();
     void persistWindowState();
     void setActiveTool(QAction* action, const QString& toolId, const QString& hint);
+    QString navigationHintForTool(const QString& toolName) const;
+    void refreshNavigationActionHints();
     void updateThemeActionIcon();
     void setRenderStyle(Renderer::RenderStyle style);
 
@@ -72,6 +75,7 @@ private:
 
     GLViewport* viewport = nullptr;
     std::unique_ptr<ToolManager> toolManager;
+    std::unique_ptr<NavigationPreferences> navigationPrefs;
     MeasurementWidget* measurementWidget = nullptr;
     QLabel* hintLabel = nullptr;
     QLabel* coordLabel = nullptr;

--- a/src/NavigationConfig.h
+++ b/src/NavigationConfig.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QtCore/Qt>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct NavigationConfig {
+    struct DragBinding {
+        Qt::MouseButton button = Qt::NoButton;
+        Qt::KeyboardModifiers modifiers = Qt::NoModifier;
+        std::string toolName;
+        bool temporary = true;
+
+        bool operator==(const DragBinding& other) const
+        {
+            return button == other.button && modifiers == other.modifiers && toolName == other.toolName
+                && temporary == other.temporary;
+        }
+
+        bool operator!=(const DragBinding& other) const { return !(*this == other); }
+    };
+
+    std::vector<DragBinding> dragBindings;
+    std::string wheelToolName = "ZoomTool";
+    bool zoomToCursor = true;
+    bool invertWheel = false;
+    float wheelStep = 1.0f;
+
+    std::optional<DragBinding> matchDrag(Qt::MouseButton button, Qt::KeyboardModifiers modifiers) const;
+};
+
+inline std::optional<NavigationConfig::DragBinding> NavigationConfig::matchDrag(Qt::MouseButton button,
+                                                                                Qt::KeyboardModifiers modifiers) const
+{
+    const Qt::KeyboardModifiers relevant = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier;
+    Qt::KeyboardModifiers sanitized = modifiers & relevant;
+    if (modifiers.testFlag(Qt::MetaModifier)) {
+        sanitized |= Qt::ControlModifier;
+    }
+
+    for (const auto& binding : dragBindings) {
+        if (binding.button != button)
+            continue;
+        if (binding.modifiers == sanitized)
+            return binding;
+    }
+    return std::nullopt;
+}

--- a/src/NavigationPreferences.cpp
+++ b/src/NavigationPreferences.cpp
@@ -1,0 +1,231 @@
+#include "NavigationPreferences.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+
+namespace {
+constexpr auto kConfigFileName = "navigation.json";
+constexpr auto kDefaultResource = ":/config/navigation_default.json";
+
+Qt::MouseButton parseButton(const QString& value)
+{
+    const QString lower = value.trimmed().toLower();
+    if (lower == QLatin1String("left"))
+        return Qt::LeftButton;
+    if (lower == QLatin1String("right"))
+        return Qt::RightButton;
+    if (lower == QLatin1String("middle"))
+        return Qt::MiddleButton;
+    if (lower == QLatin1String("aux1"))
+        return Qt::ExtraButton1;
+    if (lower == QLatin1String("aux2"))
+        return Qt::ExtraButton2;
+    return Qt::NoButton;
+}
+
+Qt::KeyboardModifiers parseModifiers(const QJsonValue& value)
+{
+    Qt::KeyboardModifiers modifiers = Qt::NoModifier;
+    auto applyToken = [&](const QString& token) {
+        const QString lower = token.trimmed().toLower();
+        if (lower == QLatin1String("shift"))
+            modifiers |= Qt::ShiftModifier;
+        else if (lower == QLatin1String("ctrl") || lower == QLatin1String("control") || lower == QLatin1String("cmd")
+                 || lower == QLatin1String("command"))
+            modifiers |= Qt::ControlModifier;
+        else if (lower == QLatin1String("alt"))
+            modifiers |= Qt::AltModifier;
+        else if (lower == QLatin1String("meta"))
+            modifiers |= Qt::ControlModifier;
+    };
+
+    if (value.isArray()) {
+        const QJsonArray array = value.toArray();
+        for (const auto& item : array) {
+            if (item.isString())
+                applyToken(item.toString());
+        }
+    } else if (value.isString()) {
+        applyToken(value.toString());
+    }
+    return modifiers;
+}
+
+} // namespace
+
+NavigationPreferences::NavigationPreferences(QObject* parent)
+    : QObject(parent)
+{
+    ensureConfigPath();
+    loadDefaults();
+    load();
+    if (activeSchemeId.isEmpty() && !defaultSchemeId.isEmpty()) {
+        setActiveScheme(defaultSchemeId);
+    }
+}
+
+QList<NavigationPreferences::SchemeInfo> NavigationPreferences::availableSchemes() const
+{
+    QList<SchemeInfo> list;
+    for (const auto& scheme : schemes) {
+        list.append(scheme.info);
+    }
+    return list;
+}
+
+NavigationConfig NavigationPreferences::schemeConfig(const QString& id) const
+{
+    if (const SchemeDefinition* scheme = findScheme(id))
+        return scheme->config;
+    return NavigationConfig{};
+}
+
+bool NavigationPreferences::setActiveScheme(const QString& id)
+{
+    const QString target = id.isEmpty() ? defaultSchemeId : id;
+    const SchemeDefinition* scheme = findScheme(target);
+    if (!scheme)
+        return false;
+
+    bool changed = (activeSchemeId != scheme->info.id) || (activeConfig.zoomToCursor != scheme->config.zoomToCursor)
+        || (activeConfig.invertWheel != scheme->config.invertWheel) || (activeConfig.wheelStep != scheme->config.wheelStep)
+        || (activeConfig.dragBindings != scheme->config.dragBindings) || (activeConfig.wheelToolName != scheme->config.wheelToolName);
+
+    activeSchemeId = scheme->info.id;
+    activeConfig = scheme->config;
+
+    if (changed)
+        emit configChanged();
+    return true;
+}
+
+void NavigationPreferences::setZoomToCursor(bool enabled)
+{
+    if (activeConfig.zoomToCursor == enabled)
+        return;
+    activeConfig.zoomToCursor = enabled;
+    emit configChanged();
+}
+
+void NavigationPreferences::setInvertWheel(bool enabled)
+{
+    if (activeConfig.invertWheel == enabled)
+        return;
+    activeConfig.invertWheel = enabled;
+    emit configChanged();
+}
+
+void NavigationPreferences::resetToDefaults()
+{
+    if (defaultSchemeId.isEmpty())
+        return;
+    setActiveScheme(defaultSchemeId);
+}
+
+void NavigationPreferences::save() const
+{
+    QJsonObject obj;
+    obj.insert(QStringLiteral("version"), schemaVersion);
+    obj.insert(QStringLiteral("activeScheme"), activeSchemeId);
+    obj.insert(QStringLiteral("zoomToCursor"), activeConfig.zoomToCursor);
+    obj.insert(QStringLiteral("invertWheel"), activeConfig.invertWheel);
+
+    QFile file(configPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return;
+    file.write(QJsonDocument(obj).toJson());
+}
+
+void NavigationPreferences::ensureConfigPath()
+{
+    const QString base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir dir(base);
+    if (!dir.exists())
+        dir.mkpath(QStringLiteral("."));
+    configPath = dir.filePath(QString::fromLatin1(kConfigFileName));
+}
+
+void NavigationPreferences::loadDefaults()
+{
+    schemes.clear();
+    QFile file(QString::fromLatin1(kDefaultResource));
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    const QJsonObject obj = doc.object();
+    schemaVersion = obj.value(QStringLiteral("version")).toInt(schemaVersion);
+    defaultSchemeId = obj.value(QStringLiteral("defaultScheme")).toString();
+
+    const QJsonArray schemeArray = obj.value(QStringLiteral("schemes")).toArray();
+    for (const auto& entry : schemeArray) {
+        if (!entry.isObject())
+            continue;
+        const QJsonObject schemeObj = entry.toObject();
+        SchemeDefinition def;
+        def.info.id = schemeObj.value(QStringLiteral("id")).toString();
+        if (def.info.id.isEmpty())
+            continue;
+        def.info.label = schemeObj.value(QStringLiteral("label")).toString(def.info.id);
+        def.info.description = schemeObj.value(QStringLiteral("description")).toString();
+        def.config.wheelToolName = schemeObj.value(QStringLiteral("wheelTool")).toString(QStringLiteral("ZoomTool")).toStdString();
+        def.config.zoomToCursor = schemeObj.value(QStringLiteral("zoomToCursor")).toBool(true);
+        def.config.invertWheel = schemeObj.value(QStringLiteral("invertWheel")).toBool(false);
+        def.config.wheelStep = static_cast<float>(schemeObj.value(QStringLiteral("wheelStep")).toDouble(1.0));
+
+        const QJsonArray bindings = schemeObj.value(QStringLiteral("dragBindings")).toArray();
+        for (const auto& bindingValue : bindings) {
+            if (!bindingValue.isObject())
+                continue;
+            const QJsonObject bindingObj = bindingValue.toObject();
+            NavigationConfig::DragBinding binding;
+            binding.button = parseButton(bindingObj.value(QStringLiteral("button")).toString());
+            binding.modifiers = parseModifiers(bindingObj.value(QStringLiteral("modifiers")));
+            binding.toolName = bindingObj.value(QStringLiteral("tool")).toString().toStdString();
+            binding.temporary = bindingObj.value(QStringLiteral("temporary")).toBool(true);
+            if (binding.button == Qt::NoButton || binding.toolName.empty())
+                continue;
+            def.config.dragBindings.push_back(binding);
+        }
+
+        schemes.push_back(def);
+    }
+
+    if (defaultSchemeId.isEmpty() && !schemes.isEmpty())
+        defaultSchemeId = schemes.front().info.id;
+}
+
+void NavigationPreferences::load()
+{
+    QFile file(configPath);
+    if (!file.exists())
+        return;
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    const QJsonObject obj = doc.object();
+    const int version = obj.value(QStringLiteral("version")).toInt(schemaVersion);
+    if (version != schemaVersion)
+        return;
+
+    const QString schemeId = obj.value(QStringLiteral("activeScheme")).toString();
+    if (!schemeId.isEmpty())
+        setActiveScheme(schemeId);
+
+    activeConfig.zoomToCursor = obj.value(QStringLiteral("zoomToCursor")).toBool(activeConfig.zoomToCursor);
+    activeConfig.invertWheel = obj.value(QStringLiteral("invertWheel")).toBool(activeConfig.invertWheel);
+
+    emit configChanged();
+}
+
+const NavigationPreferences::SchemeDefinition* NavigationPreferences::findScheme(const QString& id) const
+{
+    for (const auto& scheme : schemes) {
+        if (scheme.info.id == id)
+            return &scheme;
+    }
+    return nullptr;
+}

--- a/src/NavigationPreferences.h
+++ b/src/NavigationPreferences.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QObject>
+#include <QList>
+#include <QString>
+
+#include "NavigationConfig.h"
+
+class NavigationPreferences : public QObject {
+    Q_OBJECT
+public:
+    struct SchemeInfo {
+        QString id;
+        QString label;
+        QString description;
+    };
+
+    explicit NavigationPreferences(QObject* parent = nullptr);
+
+    const NavigationConfig& config() const { return activeConfig; }
+    QList<SchemeInfo> availableSchemes() const;
+    QString activeScheme() const { return activeSchemeId; }
+    NavigationConfig schemeConfig(const QString& id) const;
+
+    bool setActiveScheme(const QString& id);
+    void setZoomToCursor(bool enabled);
+    void setInvertWheel(bool enabled);
+    void resetToDefaults();
+    void save() const;
+
+signals:
+    void configChanged();
+
+private:
+    struct SchemeDefinition {
+        SchemeInfo info;
+        NavigationConfig config;
+    };
+
+    QList<SchemeDefinition> schemes;
+    NavigationConfig activeConfig;
+    QString activeSchemeId;
+    QString defaultSchemeId;
+    QString configPath;
+    int schemaVersion = 1;
+
+    void ensureConfigPath();
+    void loadDefaults();
+    void load();
+    const SchemeDefinition* findScheme(const QString& id) const;
+};

--- a/src/Tools/OrbitTool.cpp
+++ b/src/Tools/OrbitTool.cpp
@@ -1,0 +1,51 @@
+#include "OrbitTool.h"
+
+#include <algorithm>
+#include <cmath>
+
+OrbitTool::OrbitTool(GeometryKernel* g, CameraController* c)
+    : Tool(g, c)
+{
+}
+
+void OrbitTool::onPointerDown(const PointerInput& input)
+{
+    dragging = true;
+    lastX = input.x;
+    lastY = input.y;
+    pixelScale = std::max(input.devicePixelRatio, 1.0f);
+    setState(State::Active);
+}
+
+void OrbitTool::onPointerMove(const PointerInput& input)
+{
+    if (!dragging || !camera)
+        return;
+    float scale = std::max(pixelScale, 1.0f);
+    float dx = (input.x - lastX) / scale;
+    float dy = (input.y - lastY) / scale;
+    lastX = input.x;
+    lastY = input.y;
+    if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
+        return;
+
+    if (getModifiers().shift) {
+        camera->panCamera(dx, dy);
+    } else {
+        camera->rotateCamera(dx, dy);
+    }
+}
+
+void OrbitTool::onPointerUp(const PointerInput& input)
+{
+    lastX = input.x;
+    lastY = input.y;
+    dragging = false;
+    setState(State::Idle);
+}
+
+void OrbitTool::onCancel()
+{
+    dragging = false;
+    setState(State::Idle);
+}

--- a/src/Tools/OrbitTool.h
+++ b/src/Tools/OrbitTool.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Tool.h"
+
+class OrbitTool : public Tool {
+public:
+    OrbitTool(GeometryKernel* g, CameraController* c);
+
+    const char* getName() const override { return "OrbitTool"; }
+    bool isNavigationTool() const override { return true; }
+
+protected:
+    void onPointerDown(const PointerInput& input) override;
+    void onPointerMove(const PointerInput& input) override;
+    void onPointerUp(const PointerInput& input) override;
+    void onCancel() override;
+
+private:
+    bool dragging = false;
+    int lastX = 0;
+    int lastY = 0;
+    float pixelScale = 1.0f;
+};

--- a/src/Tools/PanTool.cpp
+++ b/src/Tools/PanTool.cpp
@@ -1,0 +1,50 @@
+#include "PanTool.h"
+
+#include <algorithm>
+#include <cmath>
+
+PanTool::PanTool(GeometryKernel* g, CameraController* c)
+    : Tool(g, c)
+{
+}
+
+void PanTool::onPointerDown(const PointerInput& input)
+{
+    dragging = true;
+    lastX = input.x;
+    lastY = input.y;
+    pixelScale = std::max(input.devicePixelRatio, 1.0f);
+    setState(State::Active);
+}
+
+void PanTool::onPointerMove(const PointerInput& input)
+{
+    if (!dragging || !camera)
+        return;
+    float scale = std::max(pixelScale, 1.0f);
+    float dx = (input.x - lastX) / scale;
+    float dy = (input.y - lastY) / scale;
+    lastX = input.x;
+    lastY = input.y;
+    if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
+        return;
+
+    if (getModifiers().alt)
+        camera->panCamera(dx * 0.5f, dy * 0.5f);
+    else
+        camera->panCamera(dx, dy);
+}
+
+void PanTool::onPointerUp(const PointerInput& input)
+{
+    lastX = input.x;
+    lastY = input.y;
+    dragging = false;
+    setState(State::Idle);
+}
+
+void PanTool::onCancel()
+{
+    dragging = false;
+    setState(State::Idle);
+}

--- a/src/Tools/PanTool.h
+++ b/src/Tools/PanTool.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Tool.h"
+
+class PanTool : public Tool {
+public:
+    PanTool(GeometryKernel* g, CameraController* c);
+
+    const char* getName() const override { return "PanTool"; }
+    bool isNavigationTool() const override { return true; }
+
+protected:
+    void onPointerDown(const PointerInput& input) override;
+    void onPointerMove(const PointerInput& input) override;
+    void onPointerUp(const PointerInput& input) override;
+    void onCancel() override;
+
+private:
+    bool dragging = false;
+    int lastX = 0;
+    int lastY = 0;
+    float pixelScale = 1.0f;
+};

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -26,6 +26,7 @@ public:
         int x = 0;
         int y = 0;
         ModifierState modifiers;
+        float devicePixelRatio = 1.0f;
     };
 
     enum class State {
@@ -105,6 +106,7 @@ public:
     virtual const char* getName() const = 0;
     virtual MeasurementKind getMeasurementKind() const { return MeasurementKind::None; }
     virtual OverrideResult applyMeasurementOverride(double) { return OverrideResult::Ignored; }
+    virtual bool isNavigationTool() const { return false; }
 
 protected:
     virtual void onPointerDown(const PointerInput&) {}

--- a/src/Tools/ToolManager.h
+++ b/src/Tools/ToolManager.h
@@ -10,8 +10,12 @@
 #include "RotateTool.h"
 #include "ScaleTool.h"
 #include "ExtrudeTool.h"
+#include "OrbitTool.h"
+#include "PanTool.h"
+#include "ZoomTool.h"
 
 #include "../Interaction/InferenceEngine.h"
+#include "../NavigationConfig.h"
 
 struct ToolInferenceUpdateRequest {
     bool hasRay = false;
@@ -23,7 +27,9 @@ class ToolManager {
 public:
     ToolManager(GeometryKernel* g, CameraController* c);
     Tool* getActiveTool() const { return active; }
-    void activateTool(const char* name);
+    void activateTool(const char* name, bool temporary = false);
+    void restorePreviousTool();
+    void setNavigationConfig(const NavigationConfig& config);
     void setViewportSize(int w, int h);
 
     void updateInference(const ToolInferenceUpdateRequest& request);
@@ -45,6 +51,9 @@ private:
 
     std::vector<std::unique_ptr<Tool>> tools;
     Tool* active = nullptr;
+    Tool* lastModelingTool = nullptr;
+    Tool* temporaryTool = nullptr;
+    Tool* previousTool = nullptr;
     int viewportWidth = 1;
     int viewportHeight = 1;
     GeometryKernel* geometry = nullptr;
@@ -62,5 +71,6 @@ private:
     bool axisAnchorValid = false;
     Vector3 lastSnapPoint;
     bool lastSnapValid = false;
+    NavigationConfig navigationConfig;
 };
 

--- a/src/Tools/ZoomTool.cpp
+++ b/src/Tools/ZoomTool.cpp
@@ -1,0 +1,121 @@
+#include "ZoomTool.h"
+
+#include "../CameraNavigation.h"
+#include "ToolGeometryUtils.h"
+
+#include <algorithm>
+#include <cmath>
+
+ZoomTool::ZoomTool(GeometryKernel* g, CameraController* c)
+    : Tool(g, c)
+{
+}
+
+void ZoomTool::onPointerDown(const PointerInput& input)
+{
+    pixelScale = std::max(input.devicePixelRatio, 1.0f);
+    lastX = input.x;
+    lastY = input.y;
+
+    if (getModifiers().ctrl) {
+        setState(State::Idle);
+        zoomExtents();
+        return;
+    }
+    if (getModifiers().alt) {
+        setState(State::Idle);
+        zoomSelection();
+        return;
+    }
+
+    dragging = true;
+    setState(State::Active);
+}
+
+void ZoomTool::onPointerMove(const PointerInput& input)
+{
+    if (!dragging || !camera)
+        return;
+
+    float scale = std::max(pixelScale, 1.0f);
+    float dy = (input.y - lastY) / scale;
+    lastX = input.x;
+    lastY = input.y;
+
+    if (std::fabs(dy) < 1e-3f)
+        return;
+
+    float delta = -dy * dragSensitivity;
+    if (getModifiers().shift)
+        delta = -delta;
+
+    applyZoomDelta(input, delta);
+}
+
+void ZoomTool::onPointerUp(const PointerInput& input)
+{
+    lastX = input.x;
+    lastY = input.y;
+    dragging = false;
+    setState(State::Idle);
+}
+
+void ZoomTool::onCancel()
+{
+    dragging = false;
+    setState(State::Idle);
+}
+
+void ZoomTool::applyZoomDelta(const PointerInput& input, float delta)
+{
+    if (!camera)
+        return;
+    if (!CameraNavigation::zoomAboutCursor(*camera, delta, input.x, input.y, viewportWidth, viewportHeight, zoomToCursor)) {
+        camera->zoomCamera(delta);
+    }
+}
+
+bool ZoomTool::zoomSelection()
+{
+    return zoomToBounds(true);
+}
+
+bool ZoomTool::zoomExtents()
+{
+    return zoomToBounds(false);
+}
+
+bool ZoomTool::zoomToBounds(bool selectedOnly)
+{
+    if (!geometry || !camera)
+        return false;
+
+    Vector3 minBounds;
+    Vector3 maxBounds;
+    bool hasBounds = false;
+
+    for (const auto& object : geometry->getObjects()) {
+        if (selectedOnly && !object->isSelected())
+            continue;
+        BoundingBox box = computeBoundingBox(*object);
+        if (!box.valid)
+            continue;
+        if (!hasBounds) {
+            minBounds = box.min;
+            maxBounds = box.max;
+            hasBounds = true;
+        } else {
+            minBounds.x = std::min(minBounds.x, box.min.x);
+            minBounds.y = std::min(minBounds.y, box.min.y);
+            minBounds.z = std::min(minBounds.z, box.min.z);
+            maxBounds.x = std::max(maxBounds.x, box.max.x);
+            maxBounds.y = std::max(maxBounds.y, box.max.y);
+            maxBounds.z = std::max(maxBounds.z, box.max.z);
+        }
+    }
+
+    if (!hasBounds)
+        return false;
+
+    return CameraNavigation::frameBounds(*camera, minBounds, maxBounds, viewportWidth, viewportHeight);
+}

--- a/src/Tools/ZoomTool.h
+++ b/src/Tools/ZoomTool.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Tool.h"
+
+class ZoomTool : public Tool {
+public:
+    ZoomTool(GeometryKernel* g, CameraController* c);
+
+    const char* getName() const override { return "ZoomTool"; }
+    bool isNavigationTool() const override { return true; }
+
+    void setZoomToCursor(bool enabled) { zoomToCursor = enabled; }
+    void setDragSensitivity(float value) { dragSensitivity = value; }
+
+protected:
+    void onPointerDown(const PointerInput& input) override;
+    void onPointerMove(const PointerInput& input) override;
+    void onPointerUp(const PointerInput& input) override;
+    void onCancel() override;
+
+private:
+    bool dragging = false;
+    int lastX = 0;
+    int lastY = 0;
+    float pixelScale = 1.0f;
+    bool zoomToCursor = true;
+    float dragSensitivity = 0.08f;
+
+    void applyZoomDelta(const PointerInput& input, float delta);
+    bool zoomSelection();
+    bool zoomExtents();
+    bool zoomToBounds(bool selectedOnly);
+};


### PR DESCRIPTION
## Summary
- add orbit, pan, and zoom tool classes that drive the camera controller and provide cursor-aware zooming helpers
- integrate navigation configuration into the tool manager, viewport input handling, and main window UI with scheme-based preferences
- bundle default navigation mappings and update build resources so toolbar buttons and shortcuts activate the new tools

## Testing
- cmake -S . -B build *(fails: Qt6 development packages are missing in the environment)*