### PR TITLE
Add hidden geometry render modes and persistence

### DIFF
--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -32,6 +32,8 @@ public:
     void setNavigationPreferences(NavigationPreferences* prefs);
     void setRenderStyle(Renderer::RenderStyle style);
     Renderer::RenderStyle getRenderStyle() const { return renderStyle; }
+    void setShowHiddenGeometry(bool show);
+    bool isHiddenGeometryVisible() const { return showHiddenGeometry; }
     ToolManager* getToolManager() const { return toolManager; }
     GeometryKernel* getGeometry() { return &geometry; }
     CameraController* getCamera() { return &camera; }
@@ -102,6 +104,7 @@ private:
     mutable int currentDrawCalls = 0;
     Renderer renderer;
     Renderer::RenderStyle renderStyle = Renderer::RenderStyle::ShadedWithEdges;
+    bool showHiddenGeometry = false;
     ViewPresetManager viewPresets;
     QString activePresetId = QStringLiteral("iso");
 };

--- a/src/GeometryKernel/GeometryObject.h
+++ b/src/GeometryKernel/GeometryObject.h
@@ -12,6 +12,12 @@ public:
     virtual HalfEdgeMesh& getMesh() = 0;
     void setSelected(bool sel) { selected = sel; }
     bool isSelected() const { return selected; }
+    void setVisible(bool vis) { visible = vis; }
+    bool isVisible() const { return visible; }
+    void setHidden(bool hiddenState) { hidden = hiddenState; }
+    bool isHidden() const { return hidden; }
 private:
     bool selected = false;
+    bool visible = true;
+    bool hidden = false;
 };

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -145,12 +145,16 @@ private:
     QAction* renderWireframeAction = nullptr;
     QAction* renderShadedAction = nullptr;
     QAction* renderShadedEdgesAction = nullptr;
+    QAction* renderHiddenLineAction = nullptr;
+    QAction* renderMonochromeAction = nullptr;
+    QAction* actionViewHiddenGeometry = nullptr;
 
     QActionGroup* toolActionGroup = nullptr;
 
     HotkeyManager hotkeys;
     bool darkTheme = true;
     Renderer::RenderStyle renderStyleChoice = Renderer::RenderStyle::ShadedWithEdges;
+    bool showHiddenGeometry = false;
     QString currentViewPresetId = QStringLiteral("iso");
     ViewPresetManager viewPresetManager;
 };

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -17,12 +17,15 @@ public:
     enum class RenderStyle {
         Wireframe,
         Shaded,
-        ShadedWithEdges
+        ShadedWithEdges,
+        HiddenLine,
+        Monochrome
     };
 
     enum class LineCategory {
         Generic,
-        Edge
+        Edge,
+        HiddenEdge
     };
 
     Renderer();
@@ -35,7 +38,9 @@ public:
                          float width,
                          bool depthTest,
                          bool blend,
-                         LineCategory category = LineCategory::Generic);
+                         LineCategory category = LineCategory::Generic,
+                         bool stippled = false,
+                         float stippleScale = 8.0f);
 
     void addLineStrip(const std::vector<QVector3D>& points,
                       const QVector4D& color,
@@ -43,7 +48,9 @@ public:
                       bool closed,
                       bool depthTest,
                       bool blend,
-                      LineCategory category = LineCategory::Generic);
+                      LineCategory category = LineCategory::Generic,
+                      bool stippled = false,
+                      float stippleScale = 8.0f);
 
     void addTriangle(const QVector3D& a,
                      const QVector3D& b,
@@ -70,6 +77,8 @@ private:
         bool depthTest = true;
         bool blend = false;
         LineCategory category = LineCategory::Generic;
+        bool stippled = false;
+        float stippleScale = 8.0f;
     };
 
     struct LineBatch {
@@ -77,7 +86,12 @@ private:
         std::vector<LineVertex> vertices;
     };
 
-    LineBatch& fetchBatch(float width, bool depthTest, bool blend, LineCategory category);
+    LineBatch& fetchBatch(float width,
+                          bool depthTest,
+                          bool blend,
+                          LineCategory category,
+                          bool stippled,
+                          float stippleScale);
 
     void ensurePrograms();
     void ensureLineState(const LineBatch& batch);


### PR DESCRIPTION
## Summary
- extend the renderer with hidden line and monochrome styles, including stippled hidden-edge support and flat monochrome shading
- add per-object visibility flags plus a View menu toggle that keeps toolbar/menu style selections and settings persistence in sync
- update viewport drawing and render tests to honor hidden geometry visibility and new style modes

## Testing
- cmake -S . -B build *(fails: Qt6Config.cmake not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc529940148321b1c09102aedeb4f4