### PR TITLE
Add section plane document support and tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ add_library(freecrafter_lib
     src/GeometryKernel/TransformUtils.cpp
     src/GeometryKernel/GeometryKernel.cpp
     src/GeometryKernel/Serialization.cpp
+    src/Scene/Document.cpp
+    src/Scene/SceneSettings.cpp
+    src/Scene/SectionPlane.cpp
     src/Tools/Tool.cpp
     src/Tools/ToolGeometryUtils.cpp
     src/Tools/LineTool.cpp
@@ -31,6 +34,7 @@ add_library(freecrafter_lib
     src/Tools/RotateTool.cpp
     src/Tools/ScaleTool.cpp
     src/Tools/ExtrudeTool.cpp
+    src/Tools/SectionTool.cpp
     src/Tools/OrbitTool.cpp
     src/Tools/PanTool.cpp
     src/Tools/ZoomTool.cpp
@@ -41,7 +45,7 @@ add_library(freecrafter_lib
     resources.qrc
 )
 
-target_include_directories(freecrafter_lib PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui)
+target_include_directories(freecrafter_lib PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui src/Scene)
 target_link_libraries(freecrafter_lib PRIVATE Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
 
 add_executable(${PROJECT_NAME}

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QMatrix4x4>
 
+#include "Scene/Document.h"
 #include "GeometryKernel/GeometryKernel.h"
 #include "CameraController.h"
 #include "Renderer.h"
@@ -35,7 +36,8 @@ public:
     void setShowHiddenGeometry(bool show);
     bool isHiddenGeometryVisible() const { return showHiddenGeometry; }
     ToolManager* getToolManager() const { return toolManager; }
-    GeometryKernel* getGeometry() { return &geometry; }
+    GeometryKernel* getGeometry() { return &document.geometry(); }
+    Scene::Document* getDocument() { return &document; }
     CameraController* getCamera() { return &camera; }
     CameraController::ProjectionMode projectionMode() const { return camera.getProjectionMode(); }
     void setProjectionMode(CameraController::ProjectionMode mode);
@@ -73,7 +75,8 @@ protected:
 private:
     void drawAxes();
     void drawGrid();
-    void drawScene();
+    void drawSceneGeometry();
+    void drawSceneOverlays();
     void drawAxisGizmo(QPainter& painter, const QMatrix4x4& viewMatrix) const;
     QMatrix4x4 buildProjectionMatrix(float aspect) const;
     QMatrix4x4 buildViewMatrix() const;
@@ -84,7 +87,7 @@ private:
     bool computeBounds(bool selectedOnly, Vector3& outMin, Vector3& outMax) const;
     bool applyZoomToBounds(const Vector3& minBounds, const Vector3& maxBounds);
 
-    GeometryKernel geometry;
+    Scene::Document document;
     CameraController camera;
     ToolManager* toolManager = nullptr;
     NavigationPreferences* navigationPrefs = nullptr;

--- a/src/GeometryKernel/GeometryKernel.cpp
+++ b/src/GeometryKernel/GeometryKernel.cpp
@@ -1,6 +1,7 @@
 #include "GeometryKernel.h"
 #include "Serialization.h"
 #include <fstream>
+#include <string>
 
 GeometryObject* GeometryKernel::addCurve(const std::vector<Vector3>& points) {
     auto obj = Curve::createFromPoints(points);
@@ -37,11 +38,19 @@ bool GeometryKernel::saveToFile(const std::string& filename) const {
     std::ofstream os(filename, std::ios::out | std::ios::trunc);
     if (!os) return false;
     os << "FCM 1\n";
-    for (const auto& up : objects) {
-        if (up->getType()==ObjectType::Curve) GeometryIO::writeCurve(os, *static_cast<const Curve*>(up.get()));
-        else if (up->getType()==ObjectType::Solid) GeometryIO::writeSolid(os, *static_cast<const Solid*>(up.get()));
-    }
+    saveToStream(os);
     return true;
+}
+
+void GeometryKernel::saveToStream(std::ostream& os) const
+{
+    for (const auto& up : objects) {
+        if (up->getType() == ObjectType::Curve) {
+            GeometryIO::writeCurve(os, *static_cast<const Curve*>(up.get()));
+        } else if (up->getType() == ObjectType::Solid) {
+            GeometryIO::writeSolid(os, *static_cast<const Solid*>(up.get()));
+        }
+    }
 }
 
 bool GeometryKernel::loadFromFile(const std::string& filename) {
@@ -49,6 +58,16 @@ bool GeometryKernel::loadFromFile(const std::string& filename) {
     if (!is) return false;
     std::string tag; int version=0; is >> tag >> version;
     if (tag!="FCM") return false;
+    if (version > 1) {
+        std::string token;
+        while (is >> token) {
+            if (token == "BEGIN_GEOMETRY") {
+                loadFromStream(is, "END_GEOMETRY");
+                break;
+            }
+        }
+        return true;
+    }
     objects.clear();
     while (is) {
         std::string type; if (!(is>>type)) break;
@@ -61,4 +80,28 @@ bool GeometryKernel::loadFromFile(const std::string& filename) {
         }
     }
     return true;
+}
+
+void GeometryKernel::loadFromStream(std::istream& is, const std::string& terminator)
+{
+    objects.clear();
+    std::string type;
+    while (is >> type) {
+        if (type == terminator) {
+            break;
+        }
+        if (type == "Curve") {
+            auto curve = GeometryIO::readCurve(is);
+            if (curve) {
+                objects.push_back(std::move(curve));
+            }
+        } else if (type == "Solid") {
+            auto solid = GeometryIO::readSolid(is);
+            if (solid) {
+                objects.push_back(std::move(solid));
+            }
+        } else {
+            break;
+        }
+    }
 }

--- a/src/GeometryKernel/GeometryKernel.h
+++ b/src/GeometryKernel/GeometryKernel.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <iosfwd>
 #include "GeometryObject.h"
 #include "Curve.h"
 #include "Solid.h"
@@ -15,6 +16,8 @@ public:
     void clear();
     bool saveToFile(const std::string& filename) const;
     bool loadFromFile(const std::string& filename);
+    void saveToStream(std::ostream& os) const;
+    void loadFromStream(std::istream& is, const std::string& terminator);
     const std::vector<std::unique_ptr<GeometryObject>>& getObjects() const { return objects; }
 private:
     std::vector<std::unique_ptr<GeometryObject>> objects;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -49,6 +49,7 @@ private slots:
     void activateRotate();
     void activateScale();
     void activateExtrude();
+    void activateSection();
     void activatePan();
     void activateOrbit();
     void activateZoom();
@@ -135,6 +136,7 @@ private:
     QAction* rotateAction = nullptr;
     QAction* scaleAction = nullptr;
     QAction* extrudeAction = nullptr;
+    QAction* sectionAction = nullptr;
     QAction* panAction = nullptr;
     QAction* orbitAction = nullptr;
     QAction* zoomAction = nullptr;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -8,6 +8,7 @@
 #include <QVector3D>
 #include <QVector4D>
 #include <vector>
+#include <array>
 
 class QOpenGLFunctions;
 
@@ -32,6 +33,7 @@ public:
 
     void initialize(QOpenGLFunctions* functions);
     void beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, RenderStyle style);
+    void setClipPlanes(const std::vector<QVector4D>& planes);
 
     void addLineSegments(const std::vector<QVector3D>& segments,
                          const QVector4D& color,
@@ -107,6 +109,9 @@ private:
 
     std::vector<LineBatch> lineBatches;
     std::vector<TriangleVertex> triangleVertices;
+
+    std::array<QVector4D, 4> clipPlanes;
+    int clipPlaneCount = 0;
 
     QMatrix4x4 mvp;
     QMatrix3x3 normalMatrix;

--- a/src/Scene/Document.cpp
+++ b/src/Scene/Document.cpp
@@ -1,0 +1,105 @@
+#include "Document.h"
+
+#include "SectionPlane.h"
+#include "SceneSettings.h"
+
+#include <fstream>
+#include <string>
+
+namespace Scene {
+
+SectionPlane& Document::addSectionPlane(const SectionPlane& plane)
+{
+    planes.push_back(plane);
+    return planes.back();
+}
+
+void Document::clearSectionPlanes()
+{
+    planes.clear();
+}
+
+void Document::reset()
+{
+    geometryKernel.clear();
+    planes.clear();
+    sceneSettings.reset();
+}
+
+bool Document::saveToFile(const std::string& filename) const
+{
+    std::ofstream os(filename, std::ios::out | std::ios::trunc);
+    if (!os) {
+        return false;
+    }
+    os << "FCM 2\n";
+    os << "BEGIN_GEOMETRY\n";
+    geometryKernel.saveToStream(os);
+    os << "END_GEOMETRY\n";
+
+    os << "BEGIN_SECTION_PLANES " << planes.size() << "\n";
+    for (const auto& plane : planes) {
+        plane.serialize(os);
+    }
+    os << "END_SECTION_PLANES\n";
+
+    os << "BEGIN_SETTINGS\n";
+    sceneSettings.serialize(os);
+    os << "END_SETTINGS\n";
+    return true;
+}
+
+bool Document::loadFromFile(const std::string& filename)
+{
+    std::ifstream is(filename);
+    if (!is) {
+        return false;
+    }
+    std::string tag;
+    int version = 0;
+    if (!(is >> tag >> version)) {
+        return false;
+    }
+    if (tag != "FCM") {
+        return false;
+    }
+
+    if (version <= 1) {
+        bool loaded = geometryKernel.loadFromFile(filename);
+        planes.clear();
+        sceneSettings.reset();
+        return loaded;
+    }
+
+    geometryKernel.clear();
+    planes.clear();
+    sceneSettings.reset();
+
+    std::string token;
+    while (is >> token) {
+        if (token == "BEGIN_GEOMETRY") {
+            geometryKernel.loadFromStream(is, "END_GEOMETRY");
+        } else if (token == "BEGIN_SECTION_PLANES") {
+            size_t count = 0;
+            is >> count;
+            planes.clear();
+            planes.reserve(count);
+            for (size_t i = 0; i < count; ++i) {
+                SectionPlane plane;
+                if (!plane.deserialize(is)) {
+                    break;
+                }
+                planes.push_back(plane);
+            }
+        } else if (token == "END_SECTION_PLANES") {
+            continue;
+        } else if (token == "BEGIN_SETTINGS") {
+            sceneSettings.deserialize(is);
+        } else if (token == "END_SETTINGS" || token == "END_GEOMETRY") {
+            continue;
+        }
+    }
+    return true;
+}
+
+} // namespace Scene

--- a/src/Scene/Document.h
+++ b/src/Scene/Document.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "SectionPlane.h"
+#include "SceneSettings.h"
+#include "../GeometryKernel/GeometryKernel.h"
+
+#include <string>
+#include <vector>
+
+namespace Scene {
+
+class Document {
+public:
+    Document() = default;
+
+    GeometryKernel& geometry() { return geometryKernel; }
+    const GeometryKernel& geometry() const { return geometryKernel; }
+
+    std::vector<SectionPlane>& sectionPlanes() { return planes; }
+    const std::vector<SectionPlane>& sectionPlanes() const { return planes; }
+
+    SceneSettings& settings() { return sceneSettings; }
+    const SceneSettings& settings() const { return sceneSettings; }
+
+    SectionPlane& addSectionPlane(const SectionPlane& plane);
+    void clearSectionPlanes();
+    void reset();
+
+    bool saveToFile(const std::string& filename) const;
+    bool loadFromFile(const std::string& filename);
+
+private:
+    GeometryKernel geometryKernel;
+    std::vector<SectionPlane> planes;
+    SceneSettings sceneSettings;
+};
+
+} // namespace Scene

--- a/src/Scene/SceneSettings.cpp
+++ b/src/Scene/SceneSettings.cpp
@@ -1,0 +1,36 @@
+#include "SceneSettings.h"
+
+#include <istream>
+#include <ostream>
+
+namespace Scene {
+
+SceneSettings::SceneSettings()
+{
+    reset();
+}
+
+void SceneSettings::reset()
+{
+    planesVisible = true;
+    fillsVisible = true;
+}
+
+void SceneSettings::serialize(std::ostream& os) const
+{
+    os << (planesVisible ? 1 : 0) << ' ' << (fillsVisible ? 1 : 0) << '\n';
+}
+
+bool SceneSettings::deserialize(std::istream& is)
+{
+    int planes = 1;
+    int fills = 1;
+    if (!(is >> planes >> fills)) {
+        return false;
+    }
+    planesVisible = planes != 0;
+    fillsVisible = fills != 0;
+    return true;
+}
+
+} // namespace Scene

--- a/src/Scene/SceneSettings.h
+++ b/src/Scene/SceneSettings.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <iosfwd>
+
+namespace Scene {
+
+class SceneSettings {
+public:
+    SceneSettings();
+
+    bool sectionPlanesVisible() const { return planesVisible; }
+    void setSectionPlanesVisible(bool value) { planesVisible = value; }
+
+    bool sectionFillsVisible() const { return fillsVisible; }
+    void setSectionFillsVisible(bool value) { fillsVisible = value; }
+
+    void reset();
+    void serialize(std::ostream& os) const;
+    bool deserialize(std::istream& is);
+
+private:
+    bool planesVisible = true;
+    bool fillsVisible = true;
+};
+
+} // namespace Scene

--- a/src/Scene/SectionPlane.cpp
+++ b/src/Scene/SectionPlane.cpp
@@ -1,0 +1,145 @@
+#include "SectionPlane.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <istream>
+#include <ostream>
+
+namespace Scene {
+namespace {
+constexpr float kEpsilon = 1e-5f;
+
+Vector3 normalizeOrFallback(const Vector3& value, const Vector3& fallback)
+{
+    float len = value.length();
+    if (len <= kEpsilon) {
+        return fallback;
+    }
+    return value / len;
+}
+}
+
+SectionPlane::SectionPlane()
+{
+    planeNormal = Vector3(0.0f, 1.0f, 0.0f);
+    planeOrigin = Vector3(0.0f, 0.0f, 0.0f);
+    transformMatrix = {
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, -1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    };
+    updateOffset();
+}
+
+void SectionPlane::setFromOriginAndNormal(const Vector3& origin, const Vector3& normal)
+{
+    planeOrigin = origin;
+    Vector3 fallback(0.0f, 1.0f, 0.0f);
+    if (std::fabs(normal.y) > 0.95f) {
+        fallback = Vector3(1.0f, 0.0f, 0.0f);
+    }
+    planeNormal = normalizeOrFallback(normal, Vector3(0.0f, 1.0f, 0.0f));
+    updateOffset();
+
+    Vector3 xAxis = planeNormal.cross(fallback);
+    if (xAxis.lengthSquared() <= kEpsilon) {
+        xAxis = planeNormal.cross(Vector3(0.0f, 0.0f, 1.0f));
+    }
+    xAxis = normalizeOrFallback(xAxis, Vector3(1.0f, 0.0f, 0.0f));
+    Vector3 yAxis = xAxis.cross(planeNormal);
+    yAxis = normalizeOrFallback(yAxis, Vector3(0.0f, 0.0f, 1.0f));
+    setBasis(xAxis, yAxis);
+}
+
+void SectionPlane::setBasis(const Vector3& xAxis, const Vector3& yAxis)
+{
+    Vector3 normal = planeNormal;
+    normal = normalizeOrFallback(normal, Vector3(0.0f, 1.0f, 0.0f));
+    Vector3 xNorm = normalizeOrFallback(xAxis, Vector3(1.0f, 0.0f, 0.0f));
+    Vector3 yNorm = normalizeOrFallback(yAxis, Vector3(0.0f, 0.0f, 1.0f));
+
+    transformMatrix = {
+        xNorm.x, xNorm.y, xNorm.z, 0.0f,
+        yNorm.x, yNorm.y, yNorm.z, 0.0f,
+        normal.x, normal.y, normal.z, 0.0f,
+        planeOrigin.x, planeOrigin.y, planeOrigin.z, 1.0f
+    };
+}
+
+void SectionPlane::setTransform(const std::array<float, 16>& columnMajorMatrix)
+{
+    transformMatrix = columnMajorMatrix;
+    planeOrigin = Vector3(transformMatrix[12], transformMatrix[13], transformMatrix[14]);
+    Vector3 normal(transformMatrix[8], transformMatrix[9], transformMatrix[10]);
+    planeNormal = normalizeOrFallback(normal, Vector3(0.0f, 1.0f, 0.0f));
+    updateOffset();
+}
+
+void SectionPlane::serialize(std::ostream& os) const
+{
+    os << planeNormal.x << ' ' << planeNormal.y << ' ' << planeNormal.z << ' ' << planeOffset << '\n';
+    os << planeOrigin.x << ' ' << planeOrigin.y << ' ' << planeOrigin.z << '\n';
+    for (size_t i = 0; i < transformMatrix.size(); ++i) {
+        os << transformMatrix[i];
+        if ((i + 1) % 4 == 0) {
+            os << '\n';
+        } else {
+            os << ' ';
+        }
+    }
+    os << fill.red << ' ' << fill.green << ' ' << fill.blue << ' ' << fill.alpha << ' ';
+    os << fill.extent << ' ' << (fill.fillEnabled ? 1 : 0) << ' ' << (visible ? 1 : 0) << ' ' << (active ? 1 : 0) << '\n';
+}
+
+bool SectionPlane::deserialize(std::istream& is)
+{
+    float nx = 0.0f, ny = 0.0f, nz = 0.0f;
+    float offset = 0.0f;
+    float ox = 0.0f, oy = 0.0f, oz = 0.0f;
+    if (!(is >> nx >> ny >> nz >> offset)) {
+        return false;
+    }
+    if (!(is >> ox >> oy >> oz)) {
+        return false;
+    }
+    planeNormal = normalizeOrFallback(Vector3(nx, ny, nz), Vector3(0.0f, 1.0f, 0.0f));
+    planeOffset = offset;
+    planeOrigin = Vector3(ox, oy, oz);
+
+    for (float& value : transformMatrix) {
+        if (!(is >> value)) {
+            return false;
+        }
+    }
+
+    int fillEnabled = 1;
+    int visibility = 1;
+    int activity = 1;
+    if (!(is >> fill.red >> fill.green >> fill.blue >> fill.alpha >> fill.extent >> fillEnabled >> visibility >> activity)) {
+        return false;
+    }
+    fill.fillEnabled = fillEnabled != 0;
+    visible = visibility != 0;
+    active = activity != 0;
+    updateOffset();
+    ensureBasis();
+    return true;
+}
+
+void SectionPlane::updateOffset()
+{
+    planeOffset = -(planeNormal.dot(planeOrigin));
+}
+
+void SectionPlane::ensureBasis()
+{
+    Vector3 xAxis(transformMatrix[0], transformMatrix[1], transformMatrix[2]);
+    Vector3 yAxis(transformMatrix[4], transformMatrix[5], transformMatrix[6]);
+    if (xAxis.lengthSquared() <= kEpsilon || yAxis.lengthSquared() <= kEpsilon) {
+        setBasis(Vector3(1.0f, 0.0f, 0.0f), Vector3(0.0f, 0.0f, 1.0f));
+    }
+}
+
+} // namespace Scene

--- a/src/Scene/SectionPlane.h
+++ b/src/Scene/SectionPlane.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../GeometryKernel/Vector3.h"
+
+#include <array>
+#include <iosfwd>
+
+namespace Scene {
+
+struct SectionFillStyle {
+    float red = 0.93f;
+    float green = 0.58f;
+    float blue = 0.24f;
+    float alpha = 0.55f;
+    float extent = 2.5f;
+    bool fillEnabled = true;
+};
+
+class SectionPlane {
+public:
+    SectionPlane();
+
+    void setFromOriginAndNormal(const Vector3& origin, const Vector3& normal);
+    void setBasis(const Vector3& xAxis, const Vector3& yAxis);
+    void setTransform(const std::array<float, 16>& columnMajorMatrix);
+
+    const Vector3& getNormal() const { return planeNormal; }
+    float getOffset() const { return planeOffset; }
+    const Vector3& getOrigin() const { return planeOrigin; }
+    const std::array<float, 16>& getTransform() const { return transformMatrix; }
+
+    SectionFillStyle& fillStyle() { return fill; }
+    const SectionFillStyle& fillStyle() const { return fill; }
+
+    bool isActive() const { return active; }
+    void setActive(bool value) { active = value; }
+
+    bool isVisible() const { return visible; }
+    void setVisible(bool value) { visible = value; }
+
+    void serialize(std::ostream& os) const;
+    bool deserialize(std::istream& is);
+
+private:
+    void updateOffset();
+    void ensureBasis();
+
+    Vector3 planeNormal;
+    float planeOffset = 0.0f;
+    Vector3 planeOrigin;
+    std::array<float, 16> transformMatrix;
+    SectionFillStyle fill;
+    bool active = true;
+    bool visible = true;
+};
+
+} // namespace Scene

--- a/src/Tools/SectionTool.cpp
+++ b/src/Tools/SectionTool.cpp
@@ -1,0 +1,138 @@
+#include "SectionTool.h"
+
+#include "../Scene/SectionPlane.h"
+
+#include <cmath>
+
+namespace {
+constexpr float kPlanePreviewExtent = 2.5f;
+constexpr float kEpsilon = 1e-5f;
+
+Vector3 safeNormalize(const Vector3& value, const Vector3& fallback)
+{
+    float len = value.length();
+    if (len <= kEpsilon) {
+        return fallback;
+    }
+    return value / len;
+}
+}
+
+SectionTool::SectionTool(GeometryKernel* geometry, CameraController* camera, Scene::Document* doc)
+    : Tool(geometry, camera)
+    , document(doc)
+{
+}
+
+void SectionTool::onPointerDown(const PointerInput&)
+{
+    if (!previewValid) {
+        return;
+    }
+    pendingPlacement = true;
+    setState(State::Active);
+}
+
+void SectionTool::onPointerUp(const PointerInput&)
+{
+    if (!pendingPlacement) {
+        return;
+    }
+    pendingPlacement = false;
+    setState(State::Idle);
+
+    if (!previewValid || !document) {
+        return;
+    }
+
+    if (document) {
+        document->settings().setSectionPlanesVisible(true);
+        document->settings().setSectionFillsVisible(true);
+    }
+
+    Scene::SectionPlane plane;
+    plane.setFromOriginAndNormal(previewOrigin, previewNormal);
+    plane.setActive(true);
+    plane.setVisible(true);
+    Scene::SectionFillStyle& style = plane.fillStyle();
+    style.extent = kPlanePreviewExtent;
+    style.fillEnabled = true;
+    document->addSectionPlane(plane);
+}
+
+void SectionTool::onPointerHover(const PointerInput&)
+{
+    refreshPreviewValidity();
+}
+
+void SectionTool::onPointerMove(const PointerInput&)
+{
+    refreshPreviewValidity();
+}
+
+void SectionTool::onCancel()
+{
+    pendingPlacement = false;
+    setState(State::Idle);
+}
+
+void SectionTool::onInferenceResultChanged(const Interaction::InferenceResult& result)
+{
+    updatePreviewFromInference(result);
+}
+
+Tool::PreviewState SectionTool::buildPreview() const
+{
+    PreviewState state;
+    if (!previewValid) {
+        return state;
+    }
+
+    Vector3 normal = safeNormalize(previewNormal, Vector3(0.0f, 1.0f, 0.0f));
+    Vector3 fallback = std::fabs(normal.y) > 0.95f ? Vector3(1.0f, 0.0f, 0.0f) : Vector3(0.0f, 1.0f, 0.0f);
+    Vector3 xAxis = normal.cross(fallback);
+    if (xAxis.lengthSquared() <= kEpsilon) {
+        xAxis = normal.cross(Vector3(0.0f, 0.0f, 1.0f));
+    }
+    xAxis = safeNormalize(xAxis, Vector3(1.0f, 0.0f, 0.0f));
+    Vector3 yAxis = xAxis.cross(normal);
+    yAxis = safeNormalize(yAxis, Vector3(0.0f, 0.0f, 1.0f));
+
+    float extent = kPlanePreviewExtent;
+    Vector3 right = xAxis * extent;
+    Vector3 up = yAxis * extent;
+
+    PreviewPolyline poly;
+    poly.closed = true;
+    poly.points.push_back(previewOrigin + right + up);
+    poly.points.push_back(previewOrigin - right + up);
+    poly.points.push_back(previewOrigin - right - up);
+    poly.points.push_back(previewOrigin + right - up);
+    state.polylines.push_back(poly);
+    return state;
+}
+
+void SectionTool::updatePreviewFromInference(const Interaction::InferenceResult& result)
+{
+    if (!result.isValid()) {
+        previewValid = false;
+        return;
+    }
+    previewOrigin = result.position;
+    if (result.direction.lengthSquared() > kEpsilon) {
+        previewNormal = result.direction.normalized();
+    } else {
+        previewNormal = Vector3(0.0f, 1.0f, 0.0f);
+    }
+    previewValid = true;
+}
+
+void SectionTool::refreshPreviewValidity()
+{
+    if (!previewValid) {
+        return;
+    }
+    if (previewNormal.lengthSquared() <= kEpsilon) {
+        previewValid = false;
+    }
+}

--- a/src/Tools/SectionTool.h
+++ b/src/Tools/SectionTool.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Tool.h"
+#include "../Scene/Document.h"
+
+class SectionTool : public Tool {
+public:
+    SectionTool(GeometryKernel* geometry, CameraController* camera, Scene::Document* document);
+
+    const char* getName() const override { return "SectionTool"; }
+
+protected:
+    void onPointerDown(const PointerInput& input) override;
+    void onPointerUp(const PointerInput& input) override;
+    void onPointerHover(const PointerInput& input) override;
+    void onPointerMove(const PointerInput& input) override;
+    void onCancel() override;
+    void onInferenceResultChanged(const Interaction::InferenceResult& result) override;
+    PreviewState buildPreview() const override;
+
+private:
+    void updatePreviewFromInference(const Interaction::InferenceResult& result);
+    void refreshPreviewValidity();
+
+    Scene::Document* document = nullptr;
+    bool pendingPlacement = false;
+    Vector3 previewOrigin{ 0.0f, 0.0f, 0.0f };
+    Vector3 previewNormal{ 0.0f, 1.0f, 0.0f };
+    bool previewValid = false;
+};

--- a/src/Tools/ToolManager.cpp
+++ b/src/Tools/ToolManager.cpp
@@ -24,19 +24,22 @@ Vector3 normalizeOrZero(const Vector3& value)
 }
 }
 
-ToolManager::ToolManager(GeometryKernel* g, CameraController* c)
-    : geometry(g)
+ToolManager::ToolManager(Scene::Document* doc, CameraController* c)
+    : geometry(doc ? &doc->geometry() : nullptr)
     , camera(c)
+    , document(doc)
 {
-    tools.push_back(std::make_unique<SmartSelectTool>(g, c));
-    tools.push_back(std::make_unique<LineTool>(g, c));
-    tools.push_back(std::make_unique<MoveTool>(g, c));
-    tools.push_back(std::make_unique<RotateTool>(g, c));
-    tools.push_back(std::make_unique<ScaleTool>(g, c));
-    tools.push_back(std::make_unique<ExtrudeTool>(g, c));
-    tools.push_back(std::make_unique<OrbitTool>(g, c));
-    tools.push_back(std::make_unique<PanTool>(g, c));
-    tools.push_back(std::make_unique<ZoomTool>(g, c));
+    GeometryKernel* gPtr = geometry;
+    tools.push_back(std::make_unique<SmartSelectTool>(gPtr, c));
+    tools.push_back(std::make_unique<LineTool>(gPtr, c));
+    tools.push_back(std::make_unique<MoveTool>(gPtr, c));
+    tools.push_back(std::make_unique<RotateTool>(gPtr, c));
+    tools.push_back(std::make_unique<ScaleTool>(gPtr, c));
+    tools.push_back(std::make_unique<ExtrudeTool>(gPtr, c));
+    tools.push_back(std::make_unique<SectionTool>(geometry, c, document));
+    tools.push_back(std::make_unique<OrbitTool>(gPtr, c));
+    tools.push_back(std::make_unique<PanTool>(gPtr, c));
+    tools.push_back(std::make_unique<ZoomTool>(gPtr, c));
     active = tools.empty() ? nullptr : tools.front().get();
     if (active && !active->isNavigationTool()) {
         lastModelingTool = active;

--- a/src/Tools/ToolManager.h
+++ b/src/Tools/ToolManager.h
@@ -10,6 +10,7 @@
 #include "RotateTool.h"
 #include "ScaleTool.h"
 #include "ExtrudeTool.h"
+#include "SectionTool.h"
 #include "OrbitTool.h"
 #include "PanTool.h"
 #include "ZoomTool.h"
@@ -25,7 +26,7 @@ struct ToolInferenceUpdateRequest {
 
 class ToolManager {
 public:
-    ToolManager(GeometryKernel* g, CameraController* c);
+    ToolManager(Scene::Document* document, CameraController* c);
     Tool* getActiveTool() const { return active; }
     void activateTool(const char* name, bool temporary = false);
     void restorePreviousTool();
@@ -58,6 +59,7 @@ private:
     int viewportHeight = 1;
     GeometryKernel* geometry = nullptr;
     CameraController* camera = nullptr;
+    Scene::Document* document = nullptr;
     Interaction::InferenceEngine inferenceEngine;
     Interaction::InferenceResult currentInference;
     Interaction::InferenceResult stickyInference;


### PR DESCRIPTION
## Summary
- add a scene document layer with section-plane data, persistence helpers, and scene settings
- extend the renderer and viewport to submit clip planes, render section fills, and display manipulators
- introduce a Section tool and wire it into the UI and tool manager for authoring section planes

## Testing
- cmake -S . -B build *(fails: Qt6 package not found)*