### PR TITLE
Add sun lighting controls and shadow rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(freecrafter_lib
     src/MainWindow.cpp
     src/GLViewport.cpp
     src/Renderer.cpp
+    src/SunModel.cpp
+    src/SunSettings.cpp
     src/CameraController.cpp
     src/CameraNavigation.cpp
     src/HotkeyManager.cpp
@@ -42,6 +44,7 @@ add_library(freecrafter_lib
     src/Interaction/InferenceEngine.cpp
     src/ui/MeasurementWidget.cpp
     src/ui/ViewSettingsDialog.cpp
+    src/ui/EnvironmentPanel.cpp
     resources.qrc
 )
 

--- a/src/GLViewport.h
+++ b/src/GLViewport.h
@@ -13,6 +13,7 @@
 #include "GeometryKernel/GeometryKernel.h"
 #include "CameraController.h"
 #include "Renderer.h"
+#include "SunSettings.h"
 #include "Navigation/ViewPresetManager.h"
 #include "NavigationConfig.h"
 
@@ -35,6 +36,8 @@ public:
     Renderer::RenderStyle getRenderStyle() const { return renderStyle; }
     void setShowHiddenGeometry(bool show);
     bool isHiddenGeometryVisible() const { return showHiddenGeometry; }
+    void setSunSettings(const SunSettings& settings);
+    const SunSettings& sunSettings() const { return environmentSettings; }
     ToolManager* getToolManager() const { return toolManager; }
     GeometryKernel* getGeometry() { return &document.geometry(); }
     Scene::Document* getDocument() { return &document; }
@@ -108,6 +111,7 @@ private:
     Renderer renderer;
     Renderer::RenderStyle renderStyle = Renderer::RenderStyle::ShadedWithEdges;
     bool showHiddenGeometry = false;
+    SunSettings environmentSettings;
     ViewPresetManager viewPresets;
     QString activePresetId = QStringLiteral("iso");
 };

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -14,12 +14,14 @@ class QTabBar;
 class QActionGroup;
 class MeasurementWidget;
 class NavigationPreferences;
+class EnvironmentPanel;
 
 #include "HotkeyManager.h"
 #include "Renderer.h"
 #include "Tools/ToolManager.h"
 #include "CameraController.h"
 #include "Navigation/ViewPresetManager.h"
+#include "SunSettings.h"
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -79,6 +81,8 @@ private:
     void updateViewPresetButtonLabel();
     void persistViewSettings() const;
     void syncViewSettingsUI();
+    void handleSunSettingsChanged(const SunSettings& settings);
+    void updateShadowStatus(const SunSettings& previous, const SunSettings& current);
 
     void closeEvent(QCloseEvent* event) override;
 
@@ -159,4 +163,6 @@ private:
     bool showHiddenGeometry = false;
     QString currentViewPresetId = QStringLiteral("iso");
     ViewPresetManager viewPresetManager;
+    SunSettings sunSettings;
+    EnvironmentPanel* environmentPanel = nullptr;
 };

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -5,9 +5,10 @@
 #include <QtMath>
 #include <utility>
 #include <algorithm>
+#include <limits>
 
 namespace {
-const char* kLineVertexShader = R"(\
+const char* kLineVertexShader = R"(
 #version 330 core
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec4 a_color;
@@ -28,7 +29,7 @@ void main() {
 }
 )";
 
-const char* kLineFragmentShader = R"(\
+const char* kLineFragmentShader = R"(
 #version 330 core
 in vec4 v_color;
 uniform float u_stippleEnabled;
@@ -46,12 +47,13 @@ void main() {
 }
 )";
 
-const char* kTriangleVertexShader = R"(\
+const char* kTriangleVertexShader = R"(
 #version 330 core
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec3 a_normal;
 layout(location = 2) in vec4 a_color;
 uniform mat4 u_mvp;
+uniform mat4 u_lightMVP;
 uniform mat3 u_normalMatrix;
 uniform vec3 u_lightDir;
 uniform int u_clipPlaneCount;
@@ -59,16 +61,19 @@ uniform vec4 u_clipPlanes[4];
 out vec3 v_normal;
 out vec4 v_color;
 out float v_lighting;
+out vec4 v_shadowCoord;
 void main() {
+    vec4 worldPosition = vec4(a_position, 1.0);
     vec3 normal = normalize(u_normalMatrix * a_normal);
     v_normal = normal;
     v_color = a_color;
     float diffuse = max(dot(normal, normalize(u_lightDir)), 0.0);
     v_lighting = diffuse;
-    gl_Position = u_mvp * vec4(a_position, 1.0);
+    v_shadowCoord = u_lightMVP * worldPosition;
+    gl_Position = u_mvp * worldPosition;
     for (int i = 0; i < 4; ++i) {
         if (i < u_clipPlaneCount) {
-            gl_ClipDistance[i] = dot(vec4(a_position, 1.0), u_clipPlanes[i]);
+            gl_ClipDistance[i] = dot(worldPosition, u_clipPlanes[i]);
         } else {
             gl_ClipDistance[i] = 1.0;
         }
@@ -76,13 +81,43 @@ void main() {
 }
 )";
 
-const char* kTriangleFragmentShader = R"(\
+const char* kTriangleFragmentShader = R"(
 #version 330 core
 in vec3 v_normal;
 in vec4 v_color;
 in float v_lighting;
+in vec4 v_shadowCoord;
 uniform int u_styleMode;
+uniform sampler2D u_shadowMap;
+uniform float u_shadowEnabled;
+uniform float u_shadowStrength;
+uniform float u_shadowBias;
+uniform vec2 u_shadowTexelSize;
+uniform int u_shadowSampleRadius;
 out vec4 fragColor;
+float computeShadow(vec4 shadowCoord) {
+    vec3 projCoords = shadowCoord.xyz / max(shadowCoord.w, 0.0001);
+    projCoords = projCoords * 0.5 + 0.5;
+    if (projCoords.z > 1.0 || projCoords.z < 0.0)
+        return 1.0;
+    if (projCoords.x < 0.0 || projCoords.x > 1.0 || projCoords.y < 0.0 || projCoords.y > 1.0)
+        return 1.0;
+    int radius = max(u_shadowSampleRadius, 0);
+    float occlusion = 0.0;
+    int samples = 0;
+    for (int x = -radius; x <= radius; ++x) {
+        for (int y = -radius; y <= radius; ++y) {
+            vec2 offset = vec2(x, y) * u_shadowTexelSize;
+            float depth = texture(u_shadowMap, projCoords.xy + offset).r;
+            occlusion += projCoords.z - u_shadowBias > depth ? 1.0 : 0.0;
+            ++samples;
+        }
+    }
+    float visibility = 1.0;
+    if (samples > 0)
+        visibility = 1.0 - clamp(occlusion / float(samples), 0.0, 1.0) * clamp(u_shadowStrength, 0.0, 1.0);
+    return clamp(visibility, 0.0, 1.0);
+}
 void main() {
     if (u_styleMode == 1) {
         vec3 base = mix(vec3(0.82), v_color.rgb, 0.35);
@@ -91,8 +126,37 @@ void main() {
     }
     float ambient = 0.25;
     float lighting = ambient + (1.0 - ambient) * clamp(v_lighting, 0.0, 1.0);
-    vec3 color = v_color.rgb * lighting;
+    float shadowFactor = 1.0;
+    if (u_shadowEnabled > 0.5) {
+        shadowFactor = computeShadow(v_shadowCoord);
+    }
+    vec3 color = v_color.rgb * lighting * shadowFactor;
     fragColor = vec4(color, v_color.a);
+}
+)";
+
+const char* kShadowVertexShader = R"(
+#version 330 core
+layout(location = 0) in vec3 a_position;
+uniform mat4 u_lightMVP;
+uniform int u_clipPlaneCount;
+uniform vec4 u_clipPlanes[4];
+void main() {
+    vec4 worldPosition = vec4(a_position, 1.0);
+    gl_Position = u_lightMVP * worldPosition;
+    for (int i = 0; i < 4; ++i) {
+        if (i < u_clipPlaneCount) {
+            gl_ClipDistance[i] = dot(worldPosition, u_clipPlanes[i]);
+        } else {
+            gl_ClipDistance[i] = 1.0;
+        }
+    }
+}
+)";
+
+const char* kShadowFragmentShader = R"(
+#version 330 core
+void main() {
 }
 )";
 }
@@ -103,22 +167,34 @@ Renderer::Renderer()
 {
 }
 
+Renderer::~Renderer()
+{
+    releaseShadowResources();
+}
+
 void Renderer::initialize(QOpenGLFunctions* funcs)
 {
     functions = funcs;
-    if (!lineBuffer.isCreated()) {
+    if (!lineBuffer.isCreated())
         lineBuffer.create();
-    }
-    if (!triangleBuffer.isCreated()) {
+    if (!triangleBuffer.isCreated())
         triangleBuffer.create();
-    }
-    if (!lineVao.isCreated()) {
+    if (!lineVao.isCreated())
         lineVao.create();
-    }
-    if (!triangleVao.isCreated()) {
+    if (!triangleVao.isCreated())
         triangleVao.create();
-    }
+    if (!shadowVao.isCreated())
+        shadowVao.create();
     programsReady = false;
+    shadowMapReady = false;
+}
+
+void Renderer::setLightingOptions(const LightingOptions& options)
+{
+    lightingOptions = options;
+    lightingOptions.shadowStrength = std::clamp(lightingOptions.shadowStrength, 0.0f, 1.0f);
+    lightingOptions.shadowBias = std::max(lightingOptions.shadowBias, 0.00005f);
+    lightingOptions.shadowSampleRadius = std::max(0, lightingOptions.shadowSampleRadius);
 }
 
 void Renderer::beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, RenderStyle style)
@@ -129,22 +205,27 @@ void Renderer::beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, 
     currentStyle = style;
     mvp = projection * view;
     normalMatrix = view.normalMatrix();
-    QVector3D lightWorld(0.3f, 0.8f, 0.6f);
-    QVector3D transformed = view.mapVector(lightWorld);
-    if (!transformed.isNull()) {
+
+    QVector3D worldDir = lightingOptions.sunValid ? lightingOptions.sunDirection : QVector3D(0.3f, 0.8f, 0.6f);
+    if (worldDir.isNull())
+        worldDir = QVector3D(0.3f, 0.8f, 0.6f);
+    QVector3D transformed = view.mapVector(worldDir);
+    if (!transformed.isNull())
         lightDir = transformed.normalized();
-    } else {
+    else
         lightDir = QVector3D(0.0f, 1.0f, 0.0f);
-    }
+
     clipPlaneCount = 0;
+    boundsValid = false;
+    triangleBufferDirty = true;
+    shadowMapReady = false;
 }
 
 void Renderer::setClipPlanes(const std::vector<QVector4D>& planes)
 {
     clipPlaneCount = std::min<int>(planes.size(), static_cast<int>(clipPlanes.size()));
-    for (int i = 0; i < clipPlaneCount; ++i) {
+    for (int i = 0; i < clipPlaneCount; ++i)
         clipPlanes[static_cast<size_t>(i)] = planes[static_cast<size_t>(i)];
-    }
 }
 
 Renderer::LineBatch& Renderer::fetchBatch(float width,
@@ -184,16 +265,13 @@ void Renderer::addLineSegments(const std::vector<QVector3D>& segments,
                                bool stippled,
                                float stippleScale)
 {
-    if (segments.size() < 2) {
+    if (segments.size() < 2)
         return;
-    }
     auto& batch = fetchBatch(width, depthTest, blend, category, stippled, stippleScale);
     batch.vertices.reserve(batch.vertices.size() + segments.size());
     for (size_t i = 1; i < segments.size(); i += 2) {
-        const QVector3D& a = segments[i - 1];
-        const QVector3D& b = segments[i];
-        batch.vertices.push_back({ a, color });
-        batch.vertices.push_back({ b, color });
+        batch.vertices.push_back({ segments[i - 1], color });
+        batch.vertices.push_back({ segments[i], color });
     }
 }
 
@@ -207,9 +285,8 @@ void Renderer::addLineStrip(const std::vector<QVector3D>& points,
                             bool stippled,
                             float stippleScale)
 {
-    if (points.size() < 2) {
+    if (points.size() < 2)
         return;
-    }
     auto& batch = fetchBatch(width, depthTest, blend, category, stippled, stippleScale);
     batch.vertices.reserve(batch.vertices.size() + (points.size() - 1 + (closed ? 1 : 0)) * 2);
     for (size_t i = 1; i < points.size(); ++i) {
@@ -231,13 +308,30 @@ void Renderer::addTriangle(const QVector3D& a,
     triangleVertices.push_back({ a, normal, color });
     triangleVertices.push_back({ b, normal, color });
     triangleVertices.push_back({ c, normal, color });
+
+    auto updateBounds = [this](const QVector3D& p) {
+        if (!boundsValid) {
+            boundsMin = boundsMax = p;
+            boundsValid = true;
+        } else {
+            boundsMin.setX(std::min(boundsMin.x(), p.x()));
+            boundsMin.setY(std::min(boundsMin.y(), p.y()));
+            boundsMin.setZ(std::min(boundsMin.z(), p.z()));
+            boundsMax.setX(std::max(boundsMax.x(), p.x()));
+            boundsMax.setY(std::max(boundsMax.y(), p.y()));
+            boundsMax.setZ(std::max(boundsMax.z(), p.z()));
+        }
+    };
+    updateBounds(a);
+    updateBounds(b);
+    updateBounds(c);
+    triangleBufferDirty = true;
 }
 
 void Renderer::ensurePrograms()
 {
-    if (programsReady) {
+    if (programsReady)
         return;
-    }
 
     if (!lineProgram.isLinked()) {
         lineProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, kLineVertexShader);
@@ -251,7 +345,23 @@ void Renderer::ensurePrograms()
         triangleProgram.link();
     }
 
-    programsReady = lineProgram.isLinked() && triangleProgram.isLinked();
+    if (!shadowProgram.isLinked()) {
+        shadowProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, kShadowVertexShader);
+        shadowProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, kShadowFragmentShader);
+        shadowProgram.link();
+    }
+
+    programsReady = lineProgram.isLinked() && triangleProgram.isLinked() && shadowProgram.isLinked();
+}
+
+void Renderer::uploadTriangleBufferIfNeeded()
+{
+    if (!triangleBufferDirty || triangleVertices.empty())
+        return;
+    QOpenGLBuffer::Binder binder(&triangleBuffer);
+    triangleBuffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    triangleBuffer.allocate(triangleVertices.data(), static_cast<int>(triangleVertices.size() * sizeof(TriangleVertex)));
+    triangleBufferDirty = false;
 }
 
 void Renderer::ensureLineState(const LineBatch& batch)
@@ -264,9 +374,8 @@ void Renderer::ensureLineState(const LineBatch& batch)
     lineProgram.bind();
     lineProgram.setUniformValue("u_mvp", mvp);
     lineProgram.setUniformValue("u_clipPlaneCount", clipPlaneCount);
-    if (clipPlaneCount > 0) {
+    if (clipPlaneCount > 0)
         lineProgram.setUniformValueArray("u_clipPlanes", clipPlanes.data(), clipPlaneCount);
-    }
     lineProgram.setUniformValue("u_stippleEnabled", batch.config.stippled ? 1.0f : 0.0f);
     lineProgram.setUniformValue("u_stippleScale", batch.config.stippleScale);
     lineProgram.enableAttributeArray(0);
@@ -276,19 +385,18 @@ void Renderer::ensureLineState(const LineBatch& batch)
 
     if (functions) {
         for (int i = 0; i < 4; ++i) {
-            if (i < clipPlaneCount) {
+            if (i < clipPlaneCount)
                 functions->glEnable(GL_CLIP_DISTANCE0 + i);
-            } else {
+            else
                 functions->glDisable(GL_CLIP_DISTANCE0 + i);
-            }
         }
     }
 
-    if (batch.config.depthTest) {
+    if (batch.config.depthTest)
         functions->glEnable(GL_DEPTH_TEST);
-    } else {
+    else
         functions->glDisable(GL_DEPTH_TEST);
-    }
+
     if (batch.config.blend) {
         functions->glEnable(GL_BLEND);
         functions->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -300,24 +408,44 @@ void Renderer::ensureLineState(const LineBatch& batch)
 
 void Renderer::ensureTriangleState()
 {
+    if (triangleVertices.empty())
+        return;
+
+    uploadTriangleBufferIfNeeded();
+
     QOpenGLVertexArrayObject::Binder binder(&triangleVao);
     triangleBuffer.bind();
-    triangleBuffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
-    triangleBuffer.allocate(triangleVertices.data(), static_cast<int>(triangleVertices.size() * sizeof(TriangleVertex)));
 
     triangleProgram.bind();
     triangleProgram.setUniformValue("u_mvp", mvp);
     triangleProgram.setUniformValue("u_normalMatrix", normalMatrix);
     triangleProgram.setUniformValue("u_lightDir", lightDir);
+    triangleProgram.setUniformValue("u_lightMVP", lightViewProjection);
     triangleProgram.setUniformValue("u_clipPlaneCount", clipPlaneCount);
-    if (clipPlaneCount > 0) {
+    if (clipPlaneCount > 0)
         triangleProgram.setUniformValueArray("u_clipPlanes", clipPlanes.data(), clipPlaneCount);
-    }
-    int styleMode = 0;
-    if (currentStyle == RenderStyle::Monochrome) {
-        styleMode = 1;
-    }
+
+    int styleMode = currentStyle == RenderStyle::Monochrome ? 1 : 0;
     triangleProgram.setUniformValue("u_styleMode", styleMode);
+
+    const bool enableShadows = shadowMapReady && lightingOptions.shadowsEnabled && lightingOptions.sunValid;
+    triangleProgram.setUniformValue("u_shadowEnabled", enableShadows ? 1.0f : 0.0f);
+    triangleProgram.setUniformValue("u_shadowStrength", lightingOptions.shadowStrength);
+    triangleProgram.setUniformValue("u_shadowBias", lightingOptions.shadowBias);
+    triangleProgram.setUniformValue("u_shadowSampleRadius", lightingOptions.shadowSampleRadius);
+    QVector2D texelSize(0.0f, 0.0f);
+    if (enableShadows && shadowMapSize > 0)
+        texelSize = QVector2D(1.0f / float(shadowMapSize), 1.0f / float(shadowMapSize));
+    triangleProgram.setUniformValue("u_shadowTexelSize", texelSize);
+    triangleProgram.setUniformValue("u_shadowMap", 0);
+
+    if (enableShadows) {
+        functions->glActiveTexture(GL_TEXTURE0);
+        functions->glBindTexture(GL_TEXTURE_2D, shadowDepthTexture);
+    } else {
+        functions->glBindTexture(GL_TEXTURE_2D, 0);
+    }
+
     triangleProgram.enableAttributeArray(0);
     triangleProgram.setAttributeBuffer(0, GL_FLOAT, offsetof(TriangleVertex, position), 3, sizeof(TriangleVertex));
     triangleProgram.enableAttributeArray(1);
@@ -329,11 +457,182 @@ void Renderer::ensureTriangleState()
     functions->glEnable(GL_DEPTH_TEST);
     functions->glLineWidth(1.0f);
     for (int i = 0; i < 4; ++i) {
-        if (i < clipPlaneCount) {
+        if (i < clipPlaneCount)
             functions->glEnable(GL_CLIP_DISTANCE0 + i);
-        } else {
+        else
             functions->glDisable(GL_CLIP_DISTANCE0 + i);
+    }
+}
+
+void Renderer::ensureShadowResources(int resolution)
+{
+    if (!functions)
+        return;
+    int size = std::max(resolution, 64);
+    if (shadowFramebuffer != 0 && shadowDepthTexture != 0 && shadowMapSize == size)
+        return;
+
+    releaseShadowResources();
+    shadowMapSize = size;
+
+    functions->glGenFramebuffers(1, &shadowFramebuffer);
+    functions->glBindFramebuffer(GL_FRAMEBUFFER, shadowFramebuffer);
+    functions->glGenTextures(1, &shadowDepthTexture);
+    functions->glBindTexture(GL_TEXTURE_2D, shadowDepthTexture);
+    functions->glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, shadowMapSize, shadowMapSize, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+    functions->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    functions->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    functions->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    functions->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    const float border[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+    functions->glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
+
+    functions->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadowDepthTexture, 0);
+    functions->glDrawBuffer(GL_NONE);
+    functions->glReadBuffer(GL_NONE);
+
+    GLenum status = functions->glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        releaseShadowResources();
+        shadowMapSize = 0;
+    }
+
+    functions->glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    functions->glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+bool Renderer::renderShadowMap()
+{
+    if (!functions)
+        return false;
+    if (!lightingOptions.shadowsEnabled || !lightingOptions.sunValid)
+        return false;
+    if (triangleVertices.empty() || !boundsValid)
+        return false;
+
+    ensurePrograms();
+    ensureShadowResources(lightingOptions.shadowMapResolution);
+    if (shadowFramebuffer == 0 || shadowDepthTexture == 0 || shadowMapSize <= 0)
+        return false;
+
+    uploadTriangleBufferIfNeeded();
+
+    QVector3D sunDir = lightingOptions.sunDirection;
+    if (sunDir.isNull())
+        sunDir = QVector3D(0.3f, 0.8f, 0.6f);
+    sunDir.normalize();
+
+    QVector3D center = (boundsMin + boundsMax) * 0.5f;
+    QVector3D diag = boundsMax - boundsMin;
+    float radius = diag.length() * 0.5f;
+    if (radius < 1.0f)
+        radius = 1.0f;
+
+    QVector3D up = QVector3D(0.0f, 1.0f, 0.0f);
+    if (std::fabs(QVector3D::dotProduct(up, sunDir)) > 0.9f)
+        up = QVector3D(0.0f, 0.0f, 1.0f);
+    QVector3D eye = center - sunDir * (radius * 2.5f + 5.0f);
+
+    lightViewMatrix.setToIdentity();
+    lightViewMatrix.lookAt(eye, center, up);
+
+    QVector3D corners[8] = {
+        { boundsMin.x(), boundsMin.y(), boundsMin.z() },
+        { boundsMax.x(), boundsMin.y(), boundsMin.z() },
+        { boundsMin.x(), boundsMax.y(), boundsMin.z() },
+        { boundsMax.x(), boundsMax.y(), boundsMin.z() },
+        { boundsMin.x(), boundsMin.y(), boundsMax.z() },
+        { boundsMax.x(), boundsMin.y(), boundsMax.z() },
+        { boundsMin.x(), boundsMax.y(), boundsMax.z() },
+        { boundsMax.x(), boundsMax.y(), boundsMax.z() }
+    };
+
+    float minX = std::numeric_limits<float>::max();
+    float maxX = -std::numeric_limits<float>::max();
+    float minY = std::numeric_limits<float>::max();
+    float maxY = -std::numeric_limits<float>::max();
+    float minZ = std::numeric_limits<float>::max();
+    float maxZ = -std::numeric_limits<float>::max();
+    for (const auto& corner : corners) {
+        QVector4D t = lightViewMatrix * QVector4D(corner, 1.0f);
+        minX = std::min(minX, t.x());
+        maxX = std::max(maxX, t.x());
+        minY = std::min(minY, t.y());
+        maxY = std::max(maxY, t.y());
+        minZ = std::min(minZ, t.z());
+        maxZ = std::max(maxZ, t.z());
+    }
+
+    float margin = std::max(radius * 0.1f, 1.0f);
+    minX -= margin;
+    maxX += margin;
+    minY -= margin;
+    maxY += margin;
+
+    float nearPlane = std::max(0.1f, -maxZ - margin);
+    float farPlane = std::max(nearPlane + 1.0f, -minZ + margin);
+
+    lightProjectionMatrix.setToIdentity();
+    lightProjectionMatrix.ortho(minX, maxX, minY, maxY, nearPlane, farPlane);
+    lightViewProjection = lightProjectionMatrix * lightViewMatrix;
+
+    GLint prevViewport[4];
+    functions->glGetIntegerv(GL_VIEWPORT, prevViewport);
+    GLint prevFbo = 0;
+    functions->glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prevFbo);
+
+    functions->glBindFramebuffer(GL_FRAMEBUFFER, shadowFramebuffer);
+    functions->glViewport(0, 0, shadowMapSize, shadowMapSize);
+    functions->glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    functions->glDisable(GL_BLEND);
+    functions->glEnable(GL_DEPTH_TEST);
+    functions->glClear(GL_DEPTH_BUFFER_BIT);
+
+    QOpenGLVertexArrayObject::Binder binder(&shadowVao);
+    triangleBuffer.bind();
+
+    shadowProgram.bind();
+    shadowProgram.setUniformValue("u_lightMVP", lightViewProjection);
+    shadowProgram.setUniformValue("u_clipPlaneCount", clipPlaneCount);
+    if (clipPlaneCount > 0)
+        shadowProgram.setUniformValueArray("u_clipPlanes", clipPlanes.data(), clipPlaneCount);
+    shadowProgram.enableAttributeArray(0);
+    shadowProgram.setAttributeBuffer(0, GL_FLOAT, offsetof(TriangleVertex, position), 3, sizeof(TriangleVertex));
+
+    if (functions) {
+        for (int i = 0; i < 4; ++i) {
+            if (i < clipPlaneCount)
+                functions->glEnable(GL_CLIP_DISTANCE0 + i);
+            else
+                functions->glDisable(GL_CLIP_DISTANCE0 + i);
         }
+    }
+
+    functions->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(triangleVertices.size()));
+
+    shadowProgram.disableAttributeArray(0);
+
+    functions->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    functions->glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
+    functions->glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+
+    for (int i = 0; i < 4; ++i)
+        functions->glDisable(GL_CLIP_DISTANCE0 + i);
+
+    return true;
+}
+
+void Renderer::releaseShadowResources()
+{
+    if (!functions)
+        return;
+    if (shadowDepthTexture) {
+        functions->glDeleteTextures(1, &shadowDepthTexture);
+        shadowDepthTexture = 0;
+    }
+    if (shadowFramebuffer) {
+        functions->glDeleteFramebuffers(1, &shadowFramebuffer);
+        shadowFramebuffer = 0;
     }
 }
 
@@ -341,6 +640,12 @@ int Renderer::flush()
 {
     ensurePrograms();
     int draws = 0;
+
+    if (!triangleVertices.empty()) {
+        shadowMapReady = renderShadowMap();
+    } else {
+        shadowMapReady = false;
+    }
 
     bool colorMaskDisabled = false;
     if (currentStyle == RenderStyle::HiddenLine) {
@@ -353,9 +658,8 @@ int Renderer::flush()
             functions->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(triangleVertices.size()));
             ++draws;
         }
-        if (colorMaskDisabled && functions) {
+        if (colorMaskDisabled && functions)
             functions->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-        }
     } else if (currentStyle != RenderStyle::Wireframe && !triangleVertices.empty()) {
         ensureTriangleState();
         functions->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(triangleVertices.size()));
@@ -363,12 +667,10 @@ int Renderer::flush()
     }
 
     for (const auto& batch : lineBatches) {
-        if (batch.vertices.empty()) {
+        if (batch.vertices.empty())
             continue;
-        }
-        if (batch.config.category == LineCategory::Edge && currentStyle == RenderStyle::Shaded) {
+        if (batch.config.category == LineCategory::Edge && currentStyle == RenderStyle::Shaded)
             continue;
-        }
         ensureLineState(batch);
         functions->glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(batch.vertices.size()));
         ++draws;
@@ -377,13 +679,10 @@ int Renderer::flush()
     functions->glDisable(GL_BLEND);
     functions->glEnable(GL_DEPTH_TEST);
     functions->glLineWidth(1.0f);
+    functions->glBindTexture(GL_TEXTURE_2D, 0);
 
-    if (functions) {
-        for (int i = 0; i < 4; ++i) {
-            functions->glDisable(GL_CLIP_DISTANCE0 + i);
-        }
-    }
+    for (int i = 0; i < 4; ++i)
+        functions->glDisable(GL_CLIP_DISTANCE0 + i);
 
     return draws;
 }
-

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -6,6 +6,7 @@
 #include <QOpenGLShaderProgram>
 #include <QOpenGLVertexArrayObject>
 #include <QVector3D>
+#include <QVector2D>
 #include <QVector4D>
 #include <vector>
 #include <array>
@@ -29,10 +30,22 @@ public:
         HiddenEdge
     };
 
+    struct LightingOptions {
+        QVector3D sunDirection = QVector3D(0.3f, 0.8f, 0.6f);
+        bool sunValid = false;
+        bool shadowsEnabled = false;
+        float shadowBias = 0.0035f;
+        float shadowStrength = 0.65f;
+        int shadowMapResolution = 1024;
+        int shadowSampleRadius = 1;
+    };
+
     Renderer();
+    ~Renderer();
 
     void initialize(QOpenGLFunctions* functions);
     void beginFrame(const QMatrix4x4& projection, const QMatrix4x4& view, RenderStyle style);
+    void setLightingOptions(const LightingOptions& options);
     void setClipPlanes(const std::vector<QVector4D>& planes);
 
     void addLineSegments(const std::vector<QVector3D>& segments,
@@ -98,17 +111,36 @@ private:
     void ensurePrograms();
     void ensureLineState(const LineBatch& batch);
     void ensureTriangleState();
+    void uploadTriangleBufferIfNeeded();
+    void ensureShadowResources(int resolution);
+    bool renderShadowMap();
+    void releaseShadowResources();
 
     QOpenGLFunctions* functions = nullptr;
     QOpenGLShaderProgram lineProgram;
     QOpenGLShaderProgram triangleProgram;
+    QOpenGLShaderProgram shadowProgram;
     QOpenGLBuffer lineBuffer;
     QOpenGLBuffer triangleBuffer;
     QOpenGLVertexArrayObject lineVao;
     QOpenGLVertexArrayObject triangleVao;
+    QOpenGLVertexArrayObject shadowVao;
 
     std::vector<LineBatch> lineBatches;
     std::vector<TriangleVertex> triangleVertices;
+
+    LightingOptions lightingOptions;
+    bool shadowMapReady = false;
+    unsigned int shadowFramebuffer = 0;
+    unsigned int shadowDepthTexture = 0;
+    int shadowMapSize = 0;
+    QMatrix4x4 lightViewMatrix;
+    QMatrix4x4 lightProjectionMatrix;
+    QMatrix4x4 lightViewProjection;
+    QVector3D boundsMin;
+    QVector3D boundsMax;
+    bool boundsValid = false;
+    bool triangleBufferDirty = true;
 
     std::array<QVector4D, 4> clipPlanes;
     int clipPlaneCount = 0;

--- a/src/SunModel.cpp
+++ b/src/SunModel.cpp
@@ -1,0 +1,127 @@
+#include "SunModel.h"
+
+#include <QDateTime>
+#include <QTimeZone>
+#include <QtMath>
+#include <cmath>
+#include <algorithm>
+
+namespace {
+constexpr double degToRad(double deg) { return deg * M_PI / 180.0; }
+constexpr double radToDeg(double rad) { return rad * 180.0 / M_PI; }
+
+double wrapDegrees(double value)
+{
+    double result = std::fmod(value, 360.0);
+    if (result < 0.0)
+        result += 360.0;
+    return result;
+}
+
+} // namespace
+
+SunModel::Result SunModel::computeSunDirection(const QDate& date,
+                                               const QTime& time,
+                                               double latitudeDegrees,
+                                               double longitudeDegrees,
+                                               int timezoneMinutes)
+{
+    Result result;
+    if (!date.isValid()) {
+        return result;
+    }
+
+    QTime effectiveTime = time.isValid() ? time : QTime(12, 0, 0);
+    QTimeZone zone(timezoneMinutes * 60);
+    QDateTime local(date, effectiveTime, zone);
+    if (!local.isValid()) {
+        local = QDateTime(date, effectiveTime, Qt::UTC);
+        local = local.addSecs(-timezoneMinutes * 60);
+    }
+
+    QDateTime utc = local.toUTC();
+    const double daySeconds = utc.time().msecsSinceStartOfDay() / 1000.0;
+    const double julianDay = utc.date().toJulianDay() + daySeconds / 86400.0;
+    const double julianCentury = (julianDay - 2451545.0) / 36525.0;
+
+    const double geomMeanLongSun = wrapDegrees(280.46646 + julianCentury * (36000.76983 + julianCentury * 0.0003032));
+    const double geomMeanAnomSun = 357.52911 + julianCentury * (35999.05029 - 0.0001537 * julianCentury);
+    const double eccentEarthOrbit = 0.016708634 - julianCentury * (0.000042037 + 0.0000001267 * julianCentury);
+
+    const double geomMeanLongSunRad = degToRad(geomMeanLongSun);
+    const double geomMeanAnomSunRad = degToRad(geomMeanAnomSun);
+
+    const double sunEqOfCenter = std::sin(geomMeanAnomSunRad) * (1.914602 - julianCentury * (0.004817 + 0.000014 * julianCentury))
+        + std::sin(2.0 * geomMeanAnomSunRad) * (0.019993 - 0.000101 * julianCentury)
+        + std::sin(3.0 * geomMeanAnomSunRad) * 0.000289;
+
+    const double sunTrueLong = geomMeanLongSun + sunEqOfCenter;
+    const double sunAppLong = sunTrueLong - 0.00569 - 0.00478 * std::sin(degToRad(125.04 - 1934.136 * julianCentury));
+
+    const double meanObliqEcliptic = 23.0 + (26.0 + ((21.448 - julianCentury * (46.815 + julianCentury * (0.00059 - julianCentury * 0.001813))) / 60.0)) / 60.0;
+    const double obliqCorr = meanObliqEcliptic + 0.00256 * std::cos(degToRad(125.04 - 1934.136 * julianCentury));
+
+    const double obliqCorrRad = degToRad(obliqCorr);
+    const double sunAppLongRad = degToRad(sunAppLong);
+    const double sunDeclination = std::asin(std::sin(obliqCorrRad) * std::sin(sunAppLongRad));
+
+    const double varY = std::tan(obliqCorrRad / 2.0);
+    const double varYSq = varY * varY;
+
+    const double eqOfTime = 4.0 * radToDeg(varYSq * std::sin(2.0 * geomMeanLongSunRad)
+                                           - 2.0 * eccentEarthOrbit * std::sin(geomMeanAnomSunRad)
+                                           + 4.0 * eccentEarthOrbit * varYSq * std::sin(geomMeanAnomSunRad) * std::cos(2.0 * geomMeanLongSunRad)
+                                           - 0.5 * varYSq * varYSq * std::sin(4.0 * geomMeanLongSunRad)
+                                           - 1.25 * eccentEarthOrbit * eccentEarthOrbit * std::sin(2.0 * geomMeanAnomSunRad));
+
+    const double timezoneHours = timezoneMinutes / 60.0;
+    const double minutes = effectiveTime.hour() * 60.0 + effectiveTime.minute() + effectiveTime.second() / 60.0;
+    double trueSolarTime = minutes + eqOfTime + 4.0 * longitudeDegrees - 60.0 * timezoneHours;
+    trueSolarTime = std::fmod(trueSolarTime, 1440.0);
+    if (trueSolarTime < 0.0)
+        trueSolarTime += 1440.0;
+
+    double hourAngle = trueSolarTime / 4.0 - 180.0;
+    if (hourAngle < -180.0)
+        hourAngle += 360.0;
+
+    const double hourAngleRad = degToRad(hourAngle);
+    const double latitudeRad = degToRad(latitudeDegrees);
+
+    double cosZenith = std::sin(latitudeRad) * std::sin(sunDeclination) + std::cos(latitudeRad) * std::cos(sunDeclination) * std::cos(hourAngleRad);
+    cosZenith = std::clamp(cosZenith, -1.0, 1.0);
+
+    const double zenith = std::acos(cosZenith);
+    const double altitude = M_PI / 2.0 - zenith;
+
+    double azimuth = std::atan2(std::sin(hourAngleRad), std::cos(hourAngleRad) * std::sin(latitudeRad) - std::tan(sunDeclination) * std::cos(latitudeRad));
+    double azimuthDeg = radToDeg(azimuth) + 180.0;
+    if (azimuthDeg < 0.0)
+        azimuthDeg += 360.0;
+    if (azimuthDeg >= 360.0)
+        azimuthDeg -= 360.0;
+
+    result.altitudeDegrees = static_cast<float>(radToDeg(altitude));
+    result.azimuthDegrees = static_cast<float>(azimuthDeg);
+
+    if (result.altitudeDegrees <= -0.5f) {
+        result.valid = false;
+        return result;
+    }
+
+    const double altitudeRad = degToRad(result.altitudeDegrees);
+    const double azimuthRad = degToRad(result.azimuthDegrees);
+
+    const double horizontal = std::cos(altitudeRad);
+    const double east = horizontal * std::sin(azimuthRad);
+    const double north = horizontal * std::cos(azimuthRad);
+    const double up = std::sin(altitudeRad);
+
+    result.direction = QVector3D(static_cast<float>(east), static_cast<float>(up), static_cast<float>(north));
+    if (!result.direction.isNull()) {
+        result.direction.normalize();
+        result.valid = true;
+    }
+
+    return result;
+}

--- a/src/SunModel.h
+++ b/src/SunModel.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QDate>
+#include <QTime>
+#include <QVector3D>
+
+class SunModel
+{
+public:
+    struct Result {
+        QVector3D direction;
+        float altitudeDegrees = 0.0f;
+        float azimuthDegrees = 0.0f;
+        bool valid = false;
+    };
+
+    static Result computeSunDirection(const QDate& date,
+                                      const QTime& time,
+                                      double latitudeDegrees,
+                                      double longitudeDegrees,
+                                      int timezoneMinutes);
+};

--- a/src/SunSettings.cpp
+++ b/src/SunSettings.cpp
@@ -1,0 +1,63 @@
+#include "SunSettings.h"
+
+#include <QDateTime>
+#include <QtGlobal>
+#include <QtMath>
+
+SunSettings::SunSettings()
+{
+    const QDateTime now = QDateTime::currentDateTime();
+    date = now.date();
+    time = now.time();
+    latitude = 37.7749; // default to San Francisco
+    longitude = -122.4194;
+    timezoneMinutes = now.offsetFromUtc() / 60;
+    daylightSaving = false;
+    shadowsEnabled = false;
+    shadowQuality = ShadowQuality::Medium;
+    shadowStrength = 0.65f;
+    shadowBias = 0.0035f;
+}
+
+int SunSettings::effectiveTimezoneMinutes() const
+{
+    return timezoneMinutes + (daylightSaving ? 60 : 0);
+}
+
+void SunSettings::save(QSettings& settings, const QString& groupName) const
+{
+    settings.beginGroup(groupName);
+    settings.setValue(QStringLiteral("date"), date);
+    settings.setValue(QStringLiteral("time"), time);
+    settings.setValue(QStringLiteral("latitude"), latitude);
+    settings.setValue(QStringLiteral("longitude"), longitude);
+    settings.setValue(QStringLiteral("timezoneMinutes"), timezoneMinutes);
+    settings.setValue(QStringLiteral("daylightSaving"), daylightSaving);
+    settings.setValue(QStringLiteral("shadowsEnabled"), shadowsEnabled);
+    settings.setValue(QStringLiteral("shadowQuality"), static_cast<int>(shadowQuality));
+    settings.setValue(QStringLiteral("shadowStrength"), static_cast<double>(shadowStrength));
+    settings.setValue(QStringLiteral("shadowBias"), static_cast<double>(shadowBias));
+    settings.endGroup();
+}
+
+void SunSettings::load(QSettings& settings, const QString& groupName)
+{
+    settings.beginGroup(groupName);
+    if (settings.contains(QStringLiteral("date")))
+        date = settings.value(QStringLiteral("date"), date).toDate();
+    if (settings.contains(QStringLiteral("time")))
+        time = settings.value(QStringLiteral("time"), time).toTime();
+    latitude = settings.value(QStringLiteral("latitude"), latitude).toDouble();
+    longitude = settings.value(QStringLiteral("longitude"), longitude).toDouble();
+    timezoneMinutes = settings.value(QStringLiteral("timezoneMinutes"), timezoneMinutes).toInt();
+    daylightSaving = settings.value(QStringLiteral("daylightSaving"), daylightSaving).toBool();
+    shadowsEnabled = settings.value(QStringLiteral("shadowsEnabled"), shadowsEnabled).toBool();
+    const int quality = settings.value(QStringLiteral("shadowQuality"), static_cast<int>(shadowQuality)).toInt();
+    if (quality >= static_cast<int>(ShadowQuality::Low) && quality <= static_cast<int>(ShadowQuality::High)) {
+        shadowQuality = static_cast<ShadowQuality>(quality);
+    }
+    shadowStrength = static_cast<float>(settings.value(QStringLiteral("shadowStrength"), static_cast<double>(shadowStrength)).toDouble());
+    shadowStrength = qBound(0.0f, shadowStrength, 1.0f);
+    shadowBias = static_cast<float>(settings.value(QStringLiteral("shadowBias"), static_cast<double>(shadowBias)).toDouble());
+    settings.endGroup();
+}

--- a/src/SunSettings.h
+++ b/src/SunSettings.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDate>
+#include <QTime>
+#include <QSettings>
+#include <QString>
+
+class SunSettings
+{
+public:
+    enum class ShadowQuality {
+        Low,
+        Medium,
+        High
+    };
+
+    SunSettings();
+
+    QDate date;
+    QTime time;
+    double latitude;
+    double longitude;
+    int timezoneMinutes;
+    bool daylightSaving;
+    bool shadowsEnabled;
+    ShadowQuality shadowQuality;
+    float shadowStrength; // 0-1 range
+    float shadowBias;
+
+    int effectiveTimezoneMinutes() const;
+
+    void save(QSettings& settings, const QString& groupName) const;
+    void load(QSettings& settings, const QString& groupName);
+};
+

--- a/src/ui/EnvironmentPanel.cpp
+++ b/src/ui/EnvironmentPanel.cpp
@@ -1,0 +1,235 @@
+#include "EnvironmentPanel.h"
+
+#include <QVBoxLayout>
+#include <QGroupBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QDateEdit>
+#include <QTimeEdit>
+#include <QSlider>
+#include <QDoubleSpinBox>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QVariant>
+#include <cmath>
+#include <algorithm>
+
+namespace {
+int timeToSliderMinutes(const QTime& time)
+{
+    if (!time.isValid())
+        return 12 * 60;
+    return time.hour() * 60 + time.minute();
+}
+
+QTime sliderToTime(int minutes)
+{
+    minutes = std::clamp(minutes, 0, 24 * 60 - 1);
+    const int hour = minutes / 60;
+    const int minute = minutes % 60;
+    return QTime(hour, minute, 0);
+}
+
+QString qualityLabel(SunSettings::ShadowQuality quality)
+{
+    switch (quality) {
+    case SunSettings::ShadowQuality::Low:
+        return QObject::tr("Low (512)");
+    case SunSettings::ShadowQuality::Medium:
+        return QObject::tr("Medium (1024)");
+    case SunSettings::ShadowQuality::High:
+        return QObject::tr("High (2048)");
+    }
+    return QObject::tr("Custom");
+}
+
+} // namespace
+
+EnvironmentPanel::EnvironmentPanel(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(12, 12, 12, 12);
+    layout->setSpacing(12);
+
+    auto* sunGroup = new QGroupBox(tr("Sun Position"), this);
+    auto* sunLayout = new QFormLayout(sunGroup);
+    sunLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+    dateEdit = new QDateEdit(this);
+    dateEdit->setCalendarPopup(true);
+    sunLayout->addRow(tr("Date"), dateEdit);
+
+    timeEdit = new QTimeEdit(this);
+    timeEdit->setDisplayFormat(QStringLiteral("HH:mm"));
+    sunLayout->addRow(tr("Time"), timeEdit);
+
+    timeSlider = new QSlider(Qt::Horizontal, this);
+    timeSlider->setRange(0, 24 * 60 - 1);
+    sunLayout->addRow(tr("Time Slider"), timeSlider);
+
+    latitudeSpin = new QDoubleSpinBox(this);
+    latitudeSpin->setRange(-90.0, 90.0);
+    latitudeSpin->setDecimals(4);
+    latitudeSpin->setSingleStep(0.1);
+    sunLayout->addRow(tr("Latitude"), latitudeSpin);
+
+    longitudeSpin = new QDoubleSpinBox(this);
+    longitudeSpin->setRange(-180.0, 180.0);
+    longitudeSpin->setDecimals(4);
+    longitudeSpin->setSingleStep(0.1);
+    sunLayout->addRow(tr("Longitude"), longitudeSpin);
+
+    timezoneSpin = new QDoubleSpinBox(this);
+    timezoneSpin->setRange(-12.0, 14.0);
+    timezoneSpin->setDecimals(2);
+    timezoneSpin->setSingleStep(0.5);
+    sunLayout->addRow(tr("UTC Offset"), timezoneSpin);
+
+    dstCheck = new QCheckBox(tr("Daylight Saving (+1h)"), this);
+    sunLayout->addRow(QString(), dstCheck);
+
+    layout->addWidget(sunGroup);
+
+    auto* shadowGroup = new QGroupBox(tr("Shadows"), this);
+    auto* shadowLayout = new QFormLayout(shadowGroup);
+    shadowLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+    shadowsCheck = new QCheckBox(tr("Cast Shadows"), this);
+    shadowLayout->addRow(QString(), shadowsCheck);
+
+    qualityCombo = new QComboBox(this);
+    qualityCombo->addItem(qualityLabel(SunSettings::ShadowQuality::Low), static_cast<int>(SunSettings::ShadowQuality::Low));
+    qualityCombo->addItem(qualityLabel(SunSettings::ShadowQuality::Medium), static_cast<int>(SunSettings::ShadowQuality::Medium));
+    qualityCombo->addItem(qualityLabel(SunSettings::ShadowQuality::High), static_cast<int>(SunSettings::ShadowQuality::High));
+    shadowLayout->addRow(tr("Quality"), qualityCombo);
+
+    strengthSlider = new QSlider(Qt::Horizontal, this);
+    strengthSlider->setRange(0, 100);
+    strengthLabel = new QLabel(this);
+    strengthLabel->setMinimumWidth(48);
+    auto* strengthContainer = new QWidget(this);
+    auto* strengthLayout = new QHBoxLayout(strengthContainer);
+    strengthLayout->setContentsMargins(0, 0, 0, 0);
+    strengthLayout->setSpacing(6);
+    strengthLayout->addWidget(strengthSlider, 1);
+    strengthLayout->addWidget(strengthLabel, 0);
+    shadowLayout->addRow(tr("Darkness"), strengthContainer);
+
+    biasSpin = new QDoubleSpinBox(this);
+    biasSpin->setRange(0.0001, 0.02);
+    biasSpin->setDecimals(4);
+    biasSpin->setSingleStep(0.0005);
+    shadowLayout->addRow(tr("Bias"), biasSpin);
+
+    layout->addWidget(shadowGroup);
+    layout->addStretch(1);
+
+    connect(dateEdit, &QDateEdit::dateChanged, this, [this](const QDate& date) {
+        current.date = date;
+        emitChanges();
+    });
+    connect(timeEdit, &QTimeEdit::timeChanged, this, &EnvironmentPanel::handleTimeChanged);
+    connect(timeSlider, &QSlider::valueChanged, this, &EnvironmentPanel::handleTimeSlider);
+    connect(latitudeSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this](double value) {
+        current.latitude = value;
+        emitChanges();
+    });
+    connect(longitudeSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this](double value) {
+        current.longitude = value;
+        emitChanges();
+    });
+    connect(timezoneSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this](double value) {
+        current.timezoneMinutes = static_cast<int>(std::round(value * 60.0));
+        emitChanges();
+    });
+    connect(dstCheck, &QCheckBox::toggled, this, [this](bool enabled) {
+        current.daylightSaving = enabled;
+        emitChanges();
+    });
+    connect(shadowsCheck, &QCheckBox::toggled, this, [this](bool enabled) {
+        current.shadowsEnabled = enabled;
+        emitChanges();
+    });
+    connect(qualityCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
+        QVariant data = qualityCombo->itemData(index);
+        if (data.isValid()) {
+            current.shadowQuality = static_cast<SunSettings::ShadowQuality>(data.toInt());
+            emitChanges();
+        }
+    });
+    connect(strengthSlider, &QSlider::valueChanged, this, [this](int value) {
+        if (strengthLabel)
+            strengthLabel->setText(tr("%1%").arg(value));
+        current.shadowStrength = static_cast<float>(value) / 100.0f;
+        emitChanges();
+    });
+    connect(biasSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this](double value) {
+        current.shadowBias = static_cast<float>(value);
+        emitChanges();
+    });
+
+    syncControls();
+}
+
+void EnvironmentPanel::setSettings(const SunSettings& settings)
+{
+    current = settings;
+    syncControls();
+}
+
+void EnvironmentPanel::syncControls()
+{
+    updating = true;
+    dateEdit->setDate(current.date);
+    timeEdit->setTime(current.time.isValid() ? current.time : QTime(12, 0, 0));
+    timeSlider->setValue(timeToSliderMinutes(timeEdit->time()));
+    latitudeSpin->setValue(current.latitude);
+    longitudeSpin->setValue(current.longitude);
+    timezoneSpin->setValue(static_cast<double>(current.timezoneMinutes) / 60.0);
+    dstCheck->setChecked(current.daylightSaving);
+    shadowsCheck->setChecked(current.shadowsEnabled);
+
+    int qualityIndex = qualityCombo->findData(static_cast<int>(current.shadowQuality));
+    if (qualityIndex >= 0)
+        qualityCombo->setCurrentIndex(qualityIndex);
+
+    int strengthValue = static_cast<int>(std::round(current.shadowStrength * 100.0f));
+    strengthSlider->setValue(strengthValue);
+    if (strengthLabel)
+        strengthLabel->setText(tr("%1%").arg(strengthValue));
+    biasSpin->setValue(current.shadowBias);
+    updating = false;
+}
+
+void EnvironmentPanel::emitChanges()
+{
+    if (updating)
+        return;
+    emit settingsChanged(current);
+}
+
+void EnvironmentPanel::handleTimeSlider(int minutes)
+{
+    if (updating)
+        return;
+    updating = true;
+    const QTime newTime = sliderToTime(minutes);
+    timeEdit->setTime(newTime);
+    updating = false;
+    current.time = newTime;
+    emit settingsChanged(current);
+}
+
+void EnvironmentPanel::handleTimeChanged(const QTime& time)
+{
+    if (updating)
+        return;
+    updating = true;
+    const int minutes = timeToSliderMinutes(time);
+    timeSlider->setValue(minutes);
+    updating = false;
+    current.time = time;
+    emit settingsChanged(current);
+}

--- a/src/ui/EnvironmentPanel.h
+++ b/src/ui/EnvironmentPanel.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QWidget>
+
+#include "SunSettings.h"
+
+class QDateEdit;
+class QTimeEdit;
+class QSlider;
+class QDoubleSpinBox;
+class QCheckBox;
+class QComboBox;
+class QLabel;
+
+class EnvironmentPanel : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit EnvironmentPanel(QWidget* parent = nullptr);
+
+    void setSettings(const SunSettings& settings);
+
+signals:
+    void settingsChanged(const SunSettings& settings);
+
+private:
+    void syncControls();
+    void emitChanges();
+
+    void handleTimeSlider(int minutes);
+    void handleTimeChanged(const QTime& time);
+
+    SunSettings current;
+    bool updating = false;
+
+    QDateEdit* dateEdit = nullptr;
+    QTimeEdit* timeEdit = nullptr;
+    QSlider* timeSlider = nullptr;
+    QDoubleSpinBox* latitudeSpin = nullptr;
+    QDoubleSpinBox* longitudeSpin = nullptr;
+    QDoubleSpinBox* timezoneSpin = nullptr;
+    QCheckBox* dstCheck = nullptr;
+    QCheckBox* shadowsCheck = nullptr;
+    QComboBox* qualityCombo = nullptr;
+    QSlider* strengthSlider = nullptr;
+    QLabel* strengthLabel = nullptr;
+    QDoubleSpinBox* biasSpin = nullptr;
+};


### PR DESCRIPTION
## Summary
- add a solar position model and persisted sun/shadow environment defaults
- expose Sun & Shadows controls in the right dock and apply the active settings to the viewport
- implement renderer shadow-map support with PCF sampling driven by the global sun vector

## Testing
- cmake -S . -B build *(fails: Qt6 SDK not installed in environment)*