### PR TITLE
Refactor hotkey serialization helpers

### DIFF
--- a/src/HotkeyManager.h
+++ b/src/HotkeyManager.h
@@ -41,4 +41,8 @@ private:
     void applyShortcut(const QString& id);
     void ensureConfigPath();
     void loadDefaults();
+    bool readShortcuts(const QJsonObject& obj, QHash<QString, QKeySequence>& target) const;
+    bool readShortcuts(const QJsonObject& obj);
+    void writeShortcuts(QJsonObject& obj, const QHash<QString, QKeySequence>& source) const;
+    void writeShortcuts(QJsonObject& obj) const;
 };


### PR DESCRIPTION
## Summary
- add reusable helpers for reading and writing shortcut JSON payloads
- refactor import, load, export, and save to route through the shared helpers
- keep default shortcut loading in sync with the new helpers while preserving schema handling

## Testing
- cmake -S . -B build *(fails: missing Qt6 configuration files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc665a34a8832185d1d2c41b0759e6