### PR TITLE
Refactor navigation drag handling

### DIFF
--- a/src/Tools/OrbitTool.cpp
+++ b/src/Tools/OrbitTool.cpp
@@ -1,31 +1,20 @@
 #include "OrbitTool.h"
 
-#include <algorithm>
 #include <cmath>
 
 OrbitTool::OrbitTool(GeometryKernel* g, CameraController* c)
-    : Tool(g, c)
+    : PointerDragTool(g, c)
 {
-}
-
-void OrbitTool::onPointerDown(const PointerInput& input)
-{
-    dragging = true;
-    lastX = input.x;
-    lastY = input.y;
-    pixelScale = std::max(input.devicePixelRatio, 1.0f);
-    setState(State::Active);
 }
 
 void OrbitTool::onPointerMove(const PointerInput& input)
 {
-    if (!dragging || !camera)
+    if (!hasActiveDrag() || !camera)
         return;
-    float scale = std::max(pixelScale, 1.0f);
-    float dx = (input.x - lastX) / scale;
-    float dy = (input.y - lastY) / scale;
-    lastX = input.x;
-    lastY = input.y;
+    float dx = 0.0f;
+    float dy = 0.0f;
+    if (!updateDragDelta(input, dx, dy))
+        return;
     if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
         return;
 
@@ -34,18 +23,4 @@ void OrbitTool::onPointerMove(const PointerInput& input)
     } else {
         camera->rotateCamera(dx, dy);
     }
-}
-
-void OrbitTool::onPointerUp(const PointerInput& input)
-{
-    lastX = input.x;
-    lastY = input.y;
-    dragging = false;
-    setState(State::Idle);
-}
-
-void OrbitTool::onCancel()
-{
-    dragging = false;
-    setState(State::Idle);
 }

--- a/src/Tools/OrbitTool.h
+++ b/src/Tools/OrbitTool.h
@@ -2,7 +2,7 @@
 
 #include "Tool.h"
 
-class OrbitTool : public Tool {
+class OrbitTool : public PointerDragTool {
 public:
     OrbitTool(GeometryKernel* g, CameraController* c);
 
@@ -10,14 +10,5 @@ public:
     bool isNavigationTool() const override { return true; }
 
 protected:
-    void onPointerDown(const PointerInput& input) override;
     void onPointerMove(const PointerInput& input) override;
-    void onPointerUp(const PointerInput& input) override;
-    void onCancel() override;
-
-private:
-    bool dragging = false;
-    int lastX = 0;
-    int lastY = 0;
-    float pixelScale = 1.0f;
 };

--- a/src/Tools/PanTool.cpp
+++ b/src/Tools/PanTool.cpp
@@ -1,31 +1,20 @@
 #include "PanTool.h"
 
-#include <algorithm>
 #include <cmath>
 
 PanTool::PanTool(GeometryKernel* g, CameraController* c)
-    : Tool(g, c)
+    : PointerDragTool(g, c)
 {
-}
-
-void PanTool::onPointerDown(const PointerInput& input)
-{
-    dragging = true;
-    lastX = input.x;
-    lastY = input.y;
-    pixelScale = std::max(input.devicePixelRatio, 1.0f);
-    setState(State::Active);
 }
 
 void PanTool::onPointerMove(const PointerInput& input)
 {
-    if (!dragging || !camera)
+    if (!hasActiveDrag() || !camera)
         return;
-    float scale = std::max(pixelScale, 1.0f);
-    float dx = (input.x - lastX) / scale;
-    float dy = (input.y - lastY) / scale;
-    lastX = input.x;
-    lastY = input.y;
+    float dx = 0.0f;
+    float dy = 0.0f;
+    if (!updateDragDelta(input, dx, dy))
+        return;
     if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
         return;
 
@@ -33,18 +22,4 @@ void PanTool::onPointerMove(const PointerInput& input)
         camera->panCamera(dx * 0.5f, dy * 0.5f);
     else
         camera->panCamera(dx, dy);
-}
-
-void PanTool::onPointerUp(const PointerInput& input)
-{
-    lastX = input.x;
-    lastY = input.y;
-    dragging = false;
-    setState(State::Idle);
-}
-
-void PanTool::onCancel()
-{
-    dragging = false;
-    setState(State::Idle);
 }

--- a/src/Tools/PanTool.h
+++ b/src/Tools/PanTool.h
@@ -2,7 +2,7 @@
 
 #include "Tool.h"
 
-class PanTool : public Tool {
+class PanTool : public PointerDragTool {
 public:
     PanTool(GeometryKernel* g, CameraController* c);
 
@@ -10,14 +10,5 @@ public:
     bool isNavigationTool() const override { return true; }
 
 protected:
-    void onPointerDown(const PointerInput& input) override;
     void onPointerMove(const PointerInput& input) override;
-    void onPointerUp(const PointerInput& input) override;
-    void onCancel() override;
-
-private:
-    bool dragging = false;
-    int lastX = 0;
-    int lastY = 0;
-    float pixelScale = 1.0f;
 };

--- a/src/Tools/Tool.cpp
+++ b/src/Tools/Tool.cpp
@@ -1,5 +1,7 @@
 #include "Tool.h"
 
+#include <algorithm>
+
 void Tool::handleMouseDown(const PointerInput& input)
 {
     updateModifiers(input.modifiers);
@@ -81,5 +83,51 @@ void Tool::updateModifiers(const ModifierState& nextModifiers)
         modifiers = nextModifiers;
         onModifiersChanged(modifiers);
     }
+}
+
+void PointerDragTool::onPointerDown(const PointerInput& input)
+{
+    dragging = true;
+    lastX = input.x;
+    lastY = input.y;
+    pixelScale = std::max(input.devicePixelRatio, 1.0f);
+    setState(State::Active);
+    onDragStart(input);
+}
+
+void PointerDragTool::onPointerUp(const PointerInput& input)
+{
+    lastX = input.x;
+    lastY = input.y;
+    if (dragging) {
+        dragging = false;
+        onDragEnd(input);
+    }
+    setState(State::Idle);
+}
+
+void PointerDragTool::onCancel()
+{
+    if (dragging) {
+        dragging = false;
+        onDragCanceled();
+    }
+    setState(State::Idle);
+}
+
+bool PointerDragTool::updateDragDelta(const PointerInput& input, float& dx, float& dy)
+{
+    if (!dragging) {
+        lastX = input.x;
+        lastY = input.y;
+        return false;
+    }
+
+    float scale = std::max(pixelScale, 1.0f);
+    dx = (input.x - lastX) / scale;
+    dy = (input.y - lastY) / scale;
+    lastX = input.x;
+    lastY = input.y;
+    return true;
 }
 

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -137,3 +137,27 @@ private:
     ModifierState modifiers;
     State state = State::Idle;
 };
+
+class PointerDragTool : public Tool {
+public:
+    using Tool::Tool;
+
+protected:
+    void onPointerDown(const PointerInput& input) override;
+    void onPointerUp(const PointerInput& input) override;
+    void onCancel() override;
+
+    bool updateDragDelta(const PointerInput& input, float& dx, float& dy);
+    bool hasActiveDrag() const { return dragging; }
+    float getPixelScale() const { return pixelScale; }
+
+    virtual void onDragStart(const PointerInput&) {}
+    virtual void onDragEnd(const PointerInput&) {}
+    virtual void onDragCanceled() {}
+
+private:
+    bool dragging = false;
+    int lastX = 0;
+    int lastY = 0;
+    float pixelScale = 1.0f;
+};


### PR DESCRIPTION
## Summary
- add a PointerDragTool helper to centralize drag state and scaling logic
- update the pan and orbit navigation tools to rely on the shared helper while preserving modifier behavior

## Testing
- cmake -S . -B build *(fails: missing Qt6 development files in the container)*