### PR TITLE
Refactor pointer drag handling for navigation tools

### DIFF
--- a/src/Tools/OrbitTool.cpp
+++ b/src/Tools/OrbitTool.cpp
@@ -7,13 +7,9 @@ OrbitTool::OrbitTool(GeometryKernel* g, CameraController* c)
 {
 }
 
-void OrbitTool::onPointerMove(const PointerInput& input)
+void OrbitTool::onDragUpdate(const PointerInput& input, float dx, float dy)
 {
-    if (!hasActiveDrag() || !camera)
-        return;
-    float dx = 0.0f;
-    float dy = 0.0f;
-    if (!updateDragDelta(input, dx, dy))
+    if (!camera)
         return;
     if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
         return;

--- a/src/Tools/OrbitTool.h
+++ b/src/Tools/OrbitTool.h
@@ -10,5 +10,5 @@ public:
     bool isNavigationTool() const override { return true; }
 
 protected:
-    void onPointerMove(const PointerInput& input) override;
+    void onDragUpdate(const PointerInput& input, float dx, float dy) override;
 };

--- a/src/Tools/PanTool.cpp
+++ b/src/Tools/PanTool.cpp
@@ -7,13 +7,9 @@ PanTool::PanTool(GeometryKernel* g, CameraController* c)
 {
 }
 
-void PanTool::onPointerMove(const PointerInput& input)
+void PanTool::onDragUpdate(const PointerInput& input, float dx, float dy)
 {
-    if (!hasActiveDrag() || !camera)
-        return;
-    float dx = 0.0f;
-    float dy = 0.0f;
-    if (!updateDragDelta(input, dx, dy))
+    if (!camera)
         return;
     if (std::fabs(dx) < 1e-3f && std::fabs(dy) < 1e-3f)
         return;

--- a/src/Tools/PanTool.h
+++ b/src/Tools/PanTool.h
@@ -10,5 +10,5 @@ public:
     bool isNavigationTool() const override { return true; }
 
 protected:
-    void onPointerMove(const PointerInput& input) override;
+    void onDragUpdate(const PointerInput& input, float dx, float dy) override;
 };

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -144,20 +144,34 @@ public:
 
 protected:
     void onPointerDown(const PointerInput& input) override;
+    void onPointerMove(const PointerInput& input) override;
     void onPointerUp(const PointerInput& input) override;
     void onCancel() override;
 
-    bool updateDragDelta(const PointerInput& input, float& dx, float& dy);
-    bool hasActiveDrag() const { return dragging; }
-    float getPixelScale() const { return pixelScale; }
+    bool hasActiveDrag() const { return dragState.isActive(); }
+    float getPixelScale() const { return dragState.getPixelScale(); }
 
     virtual void onDragStart(const PointerInput&) {}
+    virtual void onDragUpdate(const PointerInput&, float, float) {}
     virtual void onDragEnd(const PointerInput&) {}
     virtual void onDragCanceled() {}
 
 private:
-    bool dragging = false;
-    int lastX = 0;
-    int lastY = 0;
-    float pixelScale = 1.0f;
+    class DragState {
+    public:
+        void begin(const PointerInput& input);
+        bool update(const PointerInput& input, float& dx, float& dy);
+        bool finish(const PointerInput& input);
+        bool cancel();
+        bool isActive() const { return dragging; }
+        float getPixelScale() const { return pixelScale; }
+
+    private:
+        bool dragging = false;
+        int lastX = 0;
+        int lastY = 0;
+        float pixelScale = 1.0f;
+    };
+
+    DragState dragState;
 };


### PR DESCRIPTION
## Summary
- introduce a reusable DragState helper inside PointerDragTool to manage drag bookkeeping and callbacks
- route PanTool and OrbitTool move handling through onDragUpdate so they only implement camera-specific behavior
- ensure drag state transitions still flow through setState exactly once when drags start, end, or cancel

## Testing
- cmake -S . -B build *(fails: missing Qt6 development files in the environment)*