### PR TITLE
Add user feedback tasks for palette selection and onboarding guide

### DIFF
--- a/docs/status/user-feedback-tasks.md
+++ b/docs/status/user-feedback-tasks.md
@@ -1,0 +1,17 @@
+# User Feedback Tasks
+
+These tasks capture recent user feedback that needs follow-up work.
+
+:::task-stub{title="Define default object colour palette options"}
+1. Audit the current default material definitions in `src/GLViewport.cpp` and `styles/app.qss` to confirm which colours are applied to unselected, selected, monochrome, and hidden-line renders.
+2. Prototype at least three pastel-inspired palettes (e.g., light green, light purple, light blue) and document their RGBA values alongside selection highlight complements.
+3. Add a settings proposal outlining how users would choose a default palette per project (e.g., preferences dialog, project metadata), including persistence requirements.
+4. Socialize the palette options with design/UX for sign-off, then break down implementation tasks for updating shaders, UI previews, and configuration storage.
+:::
+
+:::task-stub{title="Write a troubleshooting guide for launching FreeCrafter"}
+1. Expand the README/CONTRIBUTING build sections with a step-by-step Windows walkthrough covering bootstrap, required Qt dependencies, and PATH setup, linking to automation scripts where available.
+2. Document the most common startup failures (missing Qt DLLs, CMake not on PATH, outdated Visual Studio redistributables) and add quick diagnostics/commands for each.
+3. Provide guidance for macOS/Linux users on locating Qt frameworks or using platform-specific helper scripts, noting any differences from Windows instructions.
+4. Include a checklist for validating a fresh install (first launch smoke test, logging verification) and reference future packaging docs so the guidance stays in sync with release artifacts.
+:::


### PR DESCRIPTION
## Summary
- add a user feedback tasks document under docs/status
- capture follow-up work for default object colour palettes
- outline documentation work for onboarding and troubleshooting guidance

## Testing
- not run