### PR TITLE
Clarify automation entry points in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ Welcome, creators and innovators! FreeCrafter is growing fast, and we’re calli
 4. Submit a pull request—we’ll help you get it merged.
 5. Reach out if you want to help with outreach or UI/UX!
 
+   ✅ **Windows testing checklist:**
+   - Run `powershell -ExecutionPolicy Bypass -File scripts/run_tests_with_qt_env.ps1 -UseCTest` so Qt's runtime lands on `PATH` during `ctest`.
+   - Peek at [docs/testing.md](docs/testing.md) for deeper automation tips and troubleshooting.
+
 ---
 
 Let’s craft something amazing together!  

--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ For a breakdown of planned milestones and features, see the [ROADMAP](ROADMAP.md
 
 ## Building
 
-The repository ships with a helper script that fetches a minimal Qt runtime and
+FreeCrafter ships automation that downloads Qt, configures CMake, runs the
+build, and even provisions the right environment for platform-specific test
+runs. The following sections summarize the most common entry points; deeper
+automation notes live in [docs/testing.md](docs/testing.md).
+
+### Bootstrap the toolchain
+
+The repository includes a helper script that fetches a minimal Qt runtime and
 builds the project for you. After cloning, simply run the bootstrap script:
 
 ```bash
@@ -80,19 +87,22 @@ If you prefer a graphical installer, launch:
 python scripts/gui_bootstrap.py
 ```
 
-This GUI streams progress from `bootstrap.py` and provides an "Install" button to start the build. To create a standalone executable that users can double‑click, run:
+This GUI streams progress from `bootstrap.py` and provides an "Install" button
+to start the build. To create a standalone executable that users can
+double‑click, run:
 
 ```bash
 python scripts/package_gui_bootstrap.py
 ```
 
-The command uses [PyInstaller](https://pyinstaller.org/) and writes the bundled executable to the `dist` directory.
+The command uses [PyInstaller](https://pyinstaller.org/) and writes the bundled
+executable to the `dist` directory.
 
-
-> **Note:** IDEs or language servers may report `Import "aqtinstall" could not be resolved`
-> until the packages listed in [`scripts/requirements.txt`](scripts/requirements.txt) are
-> installed for the Python interpreter they use. Creating a virtual environment and
-> ensuring `pip` points to that interpreter usually resolves the warning.
+> **Note:** IDEs or language servers may report `Import "aqtinstall" could not
+> be resolved` until the packages listed in
+> [`scripts/requirements.txt`](scripts/requirements.txt) are installed for the
+> Python interpreter they use. Creating a virtual environment and ensuring `pip`
+> points to that interpreter usually resolves the warning.
 
 The script installs its Python dependencies (including `aqtinstall`) from
 [PyPI](https://pypi.org/project/aqtinstall/) if they are missing, downloads the
@@ -104,6 +114,25 @@ The built program can be found in the `build` directory and should run on a
 machine without any additional setup.
 
 Though we hope to skip even this step in future.
+
+### Windows test helper
+
+When running the renderer regression tests on Windows, prefer the PowerShell
+wrapper in `scripts/run_tests_with_qt_env.ps1` instead of invoking `ctest`
+directly. The script extends `PATH` so the bundled Qt runtime can be found,
+sets diagnostic environment variables, and exports
+`FREECRAFTER_RENDER_SKIP_COVERAGE=1` to keep the tests stable on machines that
+fall back to the software WARP renderer.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_tests_with_qt_env.ps1 -UseCTest
+```
+
+Use raw `ctest` only if you have already bootstrapped a shell where Qt's
+`bin` directory precedes everything else on `PATH` and you are confident the
+default platform plugin works in your environment. Additional logging options
+and troubleshooting tips are collected in
+[docs/testing.md](docs/testing.md#running-the-windows-regression-test).
 
 ### Installing or Packaging
 


### PR DESCRIPTION
## Summary
- document the Windows regression test helper in the README alongside existing bootstrap automation
- link to docs/testing.md as the canonical deep-dive for automation details
- add a Windows-specific checklist to CONTRIBUTING so ctest runs with Qt on PATH

## Testing
- not run (documentation-only changes)