### PR TITLE
Ensure Qt plugin debugging during Windows CTest runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,19 @@ Icon assets are stored under `resources/icons` and bundled using Qt's resource s
 This project is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
 See [docs/testing.md](docs/testing.md) for regression test notes.
 
+### Troubleshooting Qt plugin discovery on Windows
+
+When running the automated test suite on Windows, prefer invoking the helper
+script with the `-UseCTest` flag:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_tests_with_qt_env.ps1 -UseCTest
+```
+
+The script now forces `QT_DEBUG_PLUGINS=1` for the CTest invocation and extends
+the process environment so Qt can locate its `platforms`, `styles`, and other
+plugin directories that ship alongside the bootstrapped runtime. The resulting
+log output is written directly to the console, making it easier to diagnose any
+future plugin loading failures without additional setup.
+
 


### PR DESCRIPTION
## Summary
- refactor the Windows test helper to centralize common environment setup
- set QT_DEBUG_PLUGINS whenever ctest is invoked so plugin search is logged
- document the Windows troubleshooting flow for verifying Qt plugin discovery

## Testing
- not run (Windows PowerShell tooling unavailable in the container)