### PR TITLE
Bundle Qt runtime during install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,15 @@ install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin
         BUNDLE DESTINATION .)
 
+if(COMMAND qt_generate_deploy_app_script)
+  qt_generate_deploy_app_script(
+    TARGET ${PROJECT_NAME}
+    OUTPUT_SCRIPT qt_deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
+  )
+  install(SCRIPT ${qt_deploy_script})
+endif()
+
 # Tests
 enable_testing()
 add_executable(test_render tests/test_render.cpp)


### PR DESCRIPTION
## Summary
- invoke Qt's deployment helper during installation so packaged builds include required libraries
- extend the bootstrap utility to run `cmake --install` and allow configuring the install prefix, ensuring Qt runtime files are staged alongside the executable

## Testing
- python -m compileall scripts/bootstrap.py