### PR TITLE
Improve Windows test helpers error guidance

### DIFF
--- a/scripts/run_render_regression.bat
+++ b/scripts/run_render_regression.bat
@@ -10,6 +10,17 @@ if errorlevel 1 (
   echo CTest was not found on PATH. Run from the Visual Studio Developer Prompt or add CMake/bin to PATH.
   exit /b 1
 )
+
+where test_render.exe >nul 2>nul
+if errorlevel 1 (
+  if not exist "%BUILD%\test_render.exe" (
+    echo Test binary not found at %BUILD%\test_render.exe
+    echo Configure the project with: cmake -S %ROOT% -B %BUILD%
+    echo Then build or install it with: cmake --build %BUILD% --config Release
+    exit /b 1
+  )
+)
+
 if not exist "%BUILD%\test_render.exe" (
   echo Test binary not found at %BUILD%\test_render.exe
   echo Build the tree first with: cmake --build %BUILD% --config Release

--- a/scripts/run_tests_with_qt_env.ps1
+++ b/scripts/run_tests_with_qt_env.ps1
@@ -6,19 +6,21 @@ param(
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent $scriptDir
-$qtRoot = Join-Path $repoRoot "qt/6.5.3/msvc2019_64"
-$qtBin = Join-Path $qtRoot "bin"
-$qtPlugins = Join-Path $qtRoot "plugins"
-$qtPlatformPlugins = Join-Path $qtPlugins "platforms"
 
 $cmdTool = Get-Command cmd.exe -ErrorAction SilentlyContinue
 if (-not $cmdTool) {
-    Write-Error "cmd.exe was not found on PATH. Launch the script from a standard Windows shell or ensure System32 is available." -ErrorAction Stop
+    Write-Error "cmd.exe was not found on PATH. Run this script from a Visual Studio Developer Prompt or ensure System32 is on PATH." -ErrorAction Stop
 }
+
 $ctestTool = Get-Command ctest -ErrorAction SilentlyContinue
 if ($UseCTest -and -not $ctestTool) {
     Write-Error "CTest was not found on PATH. Run from a Visual Studio Developer Prompt or add CMake's bin directory to PATH." -ErrorAction Stop
 }
+
+$qtRoot = Join-Path $repoRoot "qt/6.5.3/msvc2019_64"
+$qtBin = Join-Path $qtRoot "bin"
+$qtPlugins = Join-Path $qtRoot "plugins"
+$qtPlatformPlugins = Join-Path $qtPlugins "platforms"
 
 if (-not (Test-Path $qtBin)) {
     Write-Error "Qt runtime not found at $qtBin. Run scripts/bootstrap.py first." -ErrorAction Stop


### PR DESCRIPTION
## Summary
- check for cmd.exe and ctest availability before launching the Windows Qt test runner
- add messaging to guide users toward the Visual Studio Developer Prompt when tools are missing
- add an extra guard in the render regression batch script to help users configure and build the test binary

## Testing
- not run (non-Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2d22844f88321aa263b381bbb6bf5