### PR TITLE
Document Qt licensing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,11 @@ Icon assets are stored under `resources/icons` and bundled using Qt's resource s
 
 ## License
 This project is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
+
+FreeCrafter links against the Qt framework, which is provided under the
+LGPLv3 when using the community distribution. Distributors who ship the
+generated one-click installer must include Qt's licence texts and comply with
+the LGPL's requirements (for example providing a copy of the licence, crediting
+Qt, and allowing relinking against a different Qt build). Refer to
+[`docs/legal/qt-licensing.md`](docs/legal/qt-licensing.md) for the current
+checklist.

--- a/docs/legal/LGPLv3.txt
+++ b/docs/legal/LGPLv3.txt
@@ -1,0 +1,206 @@
+                    GNU LESSER GENERAL PUBLIC LICENSE
+                        Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+
+                    END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change. You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of
+the ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library. It
+is safest to attach them to the start of each source file to most
+effectively state the exclusion of warranty; and each file should have
+at least the "copyright" line and a pointer to where the full notice is
+found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+    USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  You should also get your employer (if you work as a programmer) or
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary. For more information on this, and how to apply and follow the
+GNU LGPL, see <https://www.gnu.org/licenses/>.

--- a/docs/legal/qt-licensing.md
+++ b/docs/legal/qt-licensing.md
@@ -1,0 +1,21 @@
+# Qt Licensing Obligations
+
+FreeCrafter's source code is published under the MIT License. When the application is built it links against the Qt 6 runtime, which is provided under the GNU Lesser General Public License version 3 (LGPLv3) unless a commercial Qt license is purchased. This document summarises the obligations that apply when redistributing FreeCrafter together with Qt under the LGPLv3 option.
+
+## Key requirements when shipping the one-click installer
+
+When the Windows installer produced by `scripts/package_build.ps1` or `scripts/package_gui_bootstrap.py` bundles Qt libraries, the distribution must meet the LGPLv3 terms:
+
+- **Provide the Qt license text.** Include the full LGPLv3 licence and the Qt third-party notices in the installer payload and ensure they are displayed or readily accessible during/after installation.
+- **Credit Qt.** Document that FreeCrafter uses the Qt framework (for example in the README, installer UI, or "About" dialog) and refer users to [https://www.qt.io](https://www.qt.io).
+- **Allow relinking with modified Qt builds.** Ship the Qt dynamic libraries unmodified (DLLs), or if static linking is ever introduced ensure object files or another relinking mechanism is provided so users can replace Qt with their own build.
+- **Offer source access.** Either provide a copy of the Qt source code that matches the bundled version or include a clear, written offer giving users instructions to obtain it (for example, a link to Qt's official download mirrors and the exact version used).
+- **Track licence compatibility.** Ensure any additional Qt modules you enable are covered by the LGPL or another compatible licence. Avoid shipping GPL-only Qt add-ons unless FreeCrafter itself adopts a GPL-compatible licence.
+
+## Repository guidance
+
+- Keep the MIT `LICENSE` file to cover FreeCrafter's original code. No changes are required to the MIT text itself.
+- Add the Qt licence text and third-party notices to the repository (for example under `docs/legal/`) so packaging scripts can copy them into the installer. This also gives developers a reference when auditing releases.
+- Update release checklists to confirm the installer includes the licence documents and satisfies the obligations above.
+
+For additional details, review the official [Qt Licensing FAQ](https://www.qt.io/faq/qt-licensing) and the [LGPLv3 text](https://www.gnu.org/licenses/lgpl-3.0.html). If FreeCrafter eventually adopts a commercial Qt licence, replace the steps above with the terms of that agreement.

--- a/docs/status/user-feedback-tasks.md
+++ b/docs/status/user-feedback-tasks.md
@@ -1,0 +1,17 @@
+# User Feedback Tasks
+
+These tasks capture recent user feedback that needs follow-up work.
+
+:::task-stub{title="Define default object colour palette options"}
+1. Audit the current default material definitions in `src/GLViewport.cpp` and `styles/app.qss` to confirm which colours are applied to unselected, selected, monochrome, and hidden-line renders.
+2. Prototype at least three pastel-inspired palettes (e.g., light green, light purple, light blue) and document their RGBA values alongside selection highlight complements.
+3. Add a settings proposal outlining how users would choose a default palette per project (e.g., preferences dialog, project metadata), including persistence requirements.
+4. Socialize the palette options with design/UX for sign-off, then break down implementation tasks for updating shaders, UI previews, and configuration storage.
+:::
+
+:::task-stub{title="Write a troubleshooting guide for launching FreeCrafter"}
+1. Expand the README/CONTRIBUTING build sections with a step-by-step Windows walkthrough covering bootstrap, required Qt dependencies, and PATH setup, linking to automation scripts where available.
+2. Document the most common startup failures (missing Qt DLLs, CMake not on PATH, outdated Visual Studio redistributables) and add quick diagnostics/commands for each.
+3. Provide guidance for macOS/Linux users on locating Qt frameworks or using platform-specific helper scripts, noting any differences from Windows instructions.
+4. Include a checklist for validating a fresh install (first launch smoke test, logging verification) and reference future packaging docs so the guidance stays in sync with release artifacts.
+:::


### PR DESCRIPTION
## Summary
- add a licensing guidance document describing the LGPL duties that apply when distributing Qt with FreeCrafter
- check in the full LGPLv3 text so packaging can bundle it alongside the installer
- reference the new guidance from the README to clarify how the MIT licence coexists with Qt's terms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee49af0d48321ab68e837c39ad583