### PR TITLE
Add Qt runtime manifest management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Build artifacts
 build/
 qt/
+!qt/
+qt/**
+!qt/.gitkeep
+!qt/README.md
+!qt/manifest.json
 
 # CMake cache and temporary files
 CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ The script also searches common install locations such as `~/Qt` on Unix
 systems or `C:/Qt` on Windows and falls back to downloading Qt if none is
 found.
 
+To update the vendored Qt runtime or refresh its metadata, use the companion
+script:
+
+```bash
+python scripts/fetch_qt_runtime.py
+```
+
+The script reads `qt/manifest.json` to determine which Qt version and modules
+to download, writes a timestamped record back to the manifest, and places the
+runtime under `qt/<version>/<arch>`. Keeping this manifest in git guarantees
+that all contributors and automated builds fetch the same Qt components.
+
 If you prefer a graphical installer, launch:
 
 ```bash
@@ -173,7 +185,9 @@ to the `build` directory.
 Icon assets are stored under `resources/icons` and bundled using Qt's resource system.  They are currently only dummy assets.
 
 ## License
-This project is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
+FreeCrafter's source code is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
+
+The application dynamically links against Qt 6, which is provided under the LGPL. If you redistribute builds that bundle Qt, make sure you follow the Qt licensing requirements summarized in [docs/legal/qt_lgpl_compliance.md](docs/legal/qt_lgpl_compliance.md) (for example, shipping the Qt license texts and offering the Qt sources).
 See [docs/testing.md](docs/testing.md) for regression test notes.
 
 ## Testing

--- a/docs/legal/qt_lgpl_compliance.md
+++ b/docs/legal/qt_lgpl_compliance.md
@@ -1,0 +1,20 @@
+# Qt LGPL Compliance Notes
+
+FreeCrafter is distributed under the MIT License, but it dynamically links against Qt 6 libraries that are provided under the GNU Lesser General Public License version 3 (LGPLv3) or later. This document summarizes the obligations that apply when shipping FreeCrafter builds that bundle Qt.
+
+## Key obligations when redistributing Qt
+
+- **Preserve the Qt license texts.** Every binary distribution must include the full LGPLv3 text and the Qt-specific notices that accompany the modules you ship. If you are deploying Qt with the bootstrap scripts, retain the `LICENSE.LGPLv3`, `LICENSE.GPL3-EXCEPT`, and `LGPL_EXCEPTION.txt` files that ship in Qt's `Licenses/` directory.
+- **Provide access to the Qt sources.** Either ship the unmodified Qt source code alongside your binaries, or provide a clear, written offer that explains how recipients can obtain the sources (for example, a URL pointing to Qt's official downloads).
+- **Allow reverse engineering for debugging.** You must not forbid recipients from reverse engineering the Qt libraries for the purposes permitted by the LGPL.
+- **Relinkability.** Because FreeCrafter uses Qt via dynamic libraries, users already have the ability to replace Qt with their own builds. Do not statically link Qt unless you are prepared to comply with the additional requirements (e.g., object file distribution).
+- **Document your Qt version and modifications.** Note the exact Qt version and any patches you apply so downstream users know which sources they need.
+
+## Recommended repository practices
+
+- Keep the project-level MIT license in `LICENSE` and point to this file from documentation.
+- Reference this compliance note (or a similar third-party notices file) from the README so distributors know about the Qt obligations.
+- Track additional third-party libraries in `docs/legal/third_party_notices.md` as they are added to the project.
+- Keep `qt/manifest.json` up to date when the Qt version or module list changes so downstream users know precisely which runtime components were shipped.
+
+These steps ensure FreeCrafter's MIT-licensed code and the LGPL-licensed Qt runtime remain compliant when shipped together.

--- a/qt/README.md
+++ b/qt/README.md
@@ -1,0 +1,15 @@
+# Vendored Qt Runtime
+
+This directory holds the Qt runtime that ships alongside FreeCrafter builds. The
+runtime is not committed to the repository, but the `manifest.json` file
+records the version and modules that should be fetched. Run
+`scripts/fetch_qt_runtime.py` to download or update the runtime using the
+configuration in the manifest.
+
+```
+python3 scripts/fetch_qt_runtime.py
+```
+
+The script will download Qt into `qt/<version>/<arch>` and refresh the manifest
+with metadata about the retrieved packages. Generated binaries or libraries
+should not be checked into git.

--- a/qt/manifest.json
+++ b/qt/manifest.json
@@ -1,0 +1,11 @@
+{
+  "version": "6.5.3",
+  "modules": [
+    "qtbase",
+    "qtimageformats",
+    "qttools",
+    "qtsvg",
+    "qttranslations"
+  ],
+  "last_updated": null
+}

--- a/scripts/fetch_qt_runtime.py
+++ b/scripts/fetch_qt_runtime.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Download or refresh the Qt runtime recorded in ``qt/manifest.json``."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import bootstrap  # noqa: E402
+
+
+def _read_manifest(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logging.warning("Unable to parse %s: %s", path, exc)
+        return {}
+
+
+def _write_manifest(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _normalise_modules(modules: List[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for module in modules:
+        key = module.strip()
+        if not key or key in seen:
+            continue
+        ordered.append(key)
+        seen.add(key)
+    return ordered
+
+
+def _install_qt(version: str, modules: List[str], *, force: bool) -> None:
+    target_dir = bootstrap.qt_root / version / bootstrap.ARCH
+    if target_dir.exists():
+        if force:
+            logging.info("Removing existing Qt runtime at %s", target_dir)
+            shutil.rmtree(target_dir)
+        else:
+            logging.info(
+                "Qt runtime already present at %s; skipping download (use --force to reinstall)",
+                target_dir,
+            )
+            return
+
+    bootstrap.ensure_aqt(offline=False, wheel_cache=None)
+    cmd = [
+        sys.executable,
+        "-m",
+        "aqtinstall",
+        "qt",
+        bootstrap.HOST,
+        "desktop",
+        version,
+        bootstrap.ARCH,
+        "-O",
+        str(bootstrap.qt_root),
+    ]
+    modules = [m for m in modules if m]
+    if modules:
+        logging.info("Requesting Qt modules: %s", ", ".join(modules))
+        cmd += ["--modules", *modules]
+    rc = bootstrap.run(cmd)
+    if rc != 0:
+        raise subprocess.CalledProcessError(rc, cmd)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--version",
+        help="Override the Qt version specified in qt/manifest.json",
+    )
+    parser.add_argument(
+        "--modules",
+        nargs="+",
+        help="Override the modules listed in qt/manifest.json (space separated)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Reinstall Qt even if the target directory already exists",
+    )
+    parser.add_argument(
+        "--update-manifest-only",
+        action="store_true",
+        help="Rewrite qt/manifest.json without downloading Qt",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(message)s")
+
+    manifest = _read_manifest(bootstrap.manifest_path)
+    version = args.version or manifest.get("version") or bootstrap.DEFAULT_QT_VERSION
+    modules = args.modules or manifest.get("modules") or bootstrap.DEFAULT_QT_MODULES
+    modules = _normalise_modules(modules)
+
+    manifest_update = {
+        "version": version,
+        "modules": modules,
+        "last_updated": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    }
+
+    if not args.update_manifest_only:
+        try:
+            _install_qt(version, modules, force=args.force)
+        except subprocess.CalledProcessError as exc:
+            logging.error(
+                "Command '%s' failed with exit code %s",
+                " ".join(map(str, exc.cmd)),
+                exc.returncode,
+            )
+            return exc.returncode
+
+    _write_manifest(bootstrap.manifest_path, manifest_update)
+    logging.info("Updated %s", bootstrap.manifest_path.relative_to(REPO_ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- track the expected Qt runtime in qt/manifest.json and document the vendored tree
- teach scripts/bootstrap.py to honour the manifest and request the recorded Qt modules
- add scripts/fetch_qt_runtime.py plus README guidance for downloading/updating the bundled Qt runtime

## Testing
- python -m compileall scripts/bootstrap.py scripts/fetch_qt_runtime.py
