### PR TITLE
Move surface painting milestone to Phase 11

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,18 @@ The following tracked milestones correspond to major roadmap items A–H:
 
 ---
 
-**How to contribute:**  
+## Phase 11 — Surface Painting & Materials
+
+- [ ] SurfacePaint tool: brush-based 3D painting with pressure/tilt-aware strokes, live masking, and viewport-aligned cursor feedback so color application matches the artist's hand movement.
+- [ ] Adaptive SmartWrap: auto-seam detection and multi-projection blending that locks texture pixels to geometry with per-face accuracy; manual seam and projection overrides for edge cases.
+- [ ] Layered material stack: base color/roughness/normal/displacement layers with blend modes, masks, and history-backed adjustments for non-destructive editing.
+- [ ] Palette & swatch UX: color stories, eyedropper sampling from scene/reference, quick-favorite decks, and per-project libraries synced with the Materials panel.
+- [ ] Brush & asset presets: save/load brush engines (tip/spacing/flow), drag-and-drop texture stamps, HDR lighting previews, and instant undo/redo with replay for confidence.
+- [ ] Immersive paint workspace UX: split-view material inspector, gesture-friendly HUD, contextual shortcuts, and onboarding tours that teach brush logic without breaking flow.
+
+---
+
+**How to contribute:**
 - If you want to help with a feature, check the [issues](../../issues) and mention the corresponding roadmap item in your PR or discussion.
 - For suggestions or clarifications, open a [discussion](../../discussions).
 

--- a/docs/planning/legal-tech-review.md
+++ b/docs/planning/legal-tech-review.md
@@ -24,3 +24,4 @@
 - [x] SPDX headers to be added gradually as files are touched (tracked in Phase 8).
 - [x] Third-party acknowledgements to live in `/docs/legal/notices.md` (to be created Phase 7).
 - [ ] Export compliance review before shipping encryption-capable plugins (Phase 10).
+- [ ] Texture/material licensing review for bundled brushes, swatches, and SmartWrap reference assets ahead of the Phase 11 surface painting release.

--- a/docs/planning/scope-lock.md
+++ b/docs/planning/scope-lock.md
@@ -17,6 +17,7 @@ FreeCrafter targets feature parity with popular CAD and archviz tools while addi
 6. **Advanced Tools (Phase 6)** – loft, fillet, subdivision, and sculpt workflows.
 7. **File I/O (Phase 7)** – full import/export stack with glTF as baseline and SKP stretch goal.
 8. **Performance & QA (Phases 8–10)** – BVH selection acceleration, autosave/recovery, localization, installer, automated QA.
+9. **Surface Painting & Materials (Phase 11, post-MVP)** – brush-driven texturing, SmartWrap UV accuracy, layered materials, and guided paint workspace UX for an artist-ready finish.
 
 ## Out of Scope for MVP
 - Cloud syncing, multi-user editing, and shared scenes.

--- a/docs/status/2025-02-11-sanity-check.md
+++ b/docs/status/2025-02-11-sanity-check.md
@@ -23,7 +23,7 @@ All tests passed. For raw output, see the execution transcript captured during t
   - UI Polish (F): ☐
   - Performance & Stability (G): ☐
   - QA & Release (H): ☐
-- Phase 4 and beyond (drawing, object management, advanced tools, etc.) are still open items.
+- Phase 4 and beyond (drawing, object management, advanced tools, etc.) are still open items, with the newly scheduled Phase 11 surface painting milestone yet to start.
 
 ## Dependency & Packaging Notes
 - `scripts/bootstrap.py` orchestrates dependency installation, Qt acquisition, CMake configuration, and bundling; it respects offline caches, CI-friendly flags, and installation prefixes.

--- a/docs/status/roadmap-progress.md
+++ b/docs/status/roadmap-progress.md
@@ -54,4 +54,6 @@ milestones already have code backing them and which ones are still open.
 * Later phases (object management, advanced modeling, file I/O, performance,
   polish, QA) remain untouched in code and should be treated as open backlog
   items despite the UI placeholders.
+* The new Phase 11 surface painting & materials milestone is currently a
+  documentation plan only and has no engineering work underway.
 


### PR DESCRIPTION
## Summary
- restore the original Phase 5–10 roadmap ordering and add Surface Painting & Materials as a new Phase 11 milestone
- update scope, legal, and status documentation to treat the surface painting work as a post-MVP target with appropriate compliance follow-up

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e3b91f228c832185f539a17a847c4c