### PR TITLE
Implement object management backend and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,11 @@ target_include_directories(test_phase4 PRIVATE src)
 target_link_libraries(test_phase4 PRIVATE freecrafter_lib Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
 add_test(NAME phase4_tools COMMAND $<TARGET_FILE:test_phase4>)
 
+add_executable(test_phase5 tests/test_phase5.cpp)
+target_include_directories(test_phase5 PRIVATE src)
+target_link_libraries(test_phase5 PRIVATE freecrafter_lib Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
+add_test(NAME phase5_object_management COMMAND $<TARGET_FILE:test_phase5>)
+
 # Include Windows redistributable if present
 
 # Uninstall target

--- a/src/GeometryKernel/Curve.cpp
+++ b/src/GeometryKernel/Curve.cpp
@@ -46,6 +46,15 @@ std::unique_ptr<Curve> Curve::createFromPoints(const std::vector<Vector3>& pts) 
     return std::unique_ptr<Curve>(new Curve(std::move(healed), std::move(mesh)));
 }
 
+std::unique_ptr<GeometryObject> Curve::clone() const
+{
+    auto copy = std::unique_ptr<Curve>(new Curve(boundaryLoop, mesh));
+    copy->setSelected(isSelected());
+    copy->setVisible(isVisible());
+    copy->setHidden(isHidden());
+    return copy;
+}
+
 void Curve::applyTransform(const std::function<Vector3(const Vector3&)>& fn)
 {
     for (auto& point : boundaryLoop) {

--- a/src/GeometryKernel/Curve.h
+++ b/src/GeometryKernel/Curve.h
@@ -11,6 +11,7 @@ public:
     ObjectType getType() const override { return ObjectType::Curve; }
     const HalfEdgeMesh& getMesh() const override { return mesh; }
     HalfEdgeMesh& getMesh() override { return mesh; }
+    std::unique_ptr<GeometryObject> clone() const override;
 
     const std::vector<Vector3>& getBoundaryLoop() const { return boundaryLoop; }
 

--- a/src/GeometryKernel/GeometryKernel.cpp
+++ b/src/GeometryKernel/GeometryKernel.cpp
@@ -27,6 +27,29 @@ GeometryObject* GeometryKernel::extrudeCurve(GeometryObject* curveObj, float hei
     return raw;
 }
 
+GeometryObject* GeometryKernel::addObject(std::unique_ptr<GeometryObject> object)
+{
+    if (!object)
+        return nullptr;
+    GeometryObject* raw = object.get();
+    objects.push_back(std::move(object));
+    return raw;
+}
+
+GeometryObject* GeometryKernel::cloneObject(const GeometryObject& source)
+{
+    auto clone = source.clone();
+    if (!clone)
+        return nullptr;
+    GeometryObject* raw = clone.get();
+    objects.push_back(std::move(clone));
+    auto it = materialAssignments.find(&source);
+    if (it != materialAssignments.end()) {
+        materialAssignments[raw] = it->second;
+    }
+    return raw;
+}
+
 void GeometryKernel::deleteObject(GeometryObject* obj) {
     if (!obj) return;
     for (auto it = objects.begin(); it != objects.end(); ++it) {

--- a/src/GeometryKernel/GeometryKernel.h
+++ b/src/GeometryKernel/GeometryKernel.h
@@ -13,6 +13,8 @@ public:
     GeometryKernel() = default;
     GeometryObject* addCurve(const std::vector<Vector3>& points);
     GeometryObject* extrudeCurve(GeometryObject* curveObj, float height);
+    GeometryObject* addObject(std::unique_ptr<GeometryObject> object);
+    GeometryObject* cloneObject(const GeometryObject& source);
     void deleteObject(GeometryObject* obj);
     void clear();
     bool saveToFile(const std::string& filename) const;

--- a/src/GeometryKernel/GeometryObject.h
+++ b/src/GeometryKernel/GeometryObject.h
@@ -2,6 +2,8 @@
 #include "Vector3.h"
 #include "HalfEdgeMesh.h"
 
+#include <memory>
+
 enum class ObjectType { Curve, Solid };
 
 class GeometryObject {
@@ -10,6 +12,7 @@ public:
     virtual ObjectType getType() const = 0;
     virtual const HalfEdgeMesh& getMesh() const = 0;
     virtual HalfEdgeMesh& getMesh() = 0;
+    virtual std::unique_ptr<GeometryObject> clone() const = 0;
     void setSelected(bool sel) { selected = sel; }
     bool isSelected() const { return selected; }
     void setVisible(bool vis) { visible = vis; }

--- a/src/GeometryKernel/Solid.cpp
+++ b/src/GeometryKernel/Solid.cpp
@@ -106,3 +106,12 @@ void Solid::scale(const Vector3& pivot, const Vector3& factors)
 {
     applyTransform([&](const Vector3& p) { return GeometryTransforms::scaleFromPivot(p, pivot, factors); });
 }
+
+std::unique_ptr<GeometryObject> Solid::clone() const
+{
+    auto copy = std::unique_ptr<Solid>(new Solid(baseLoop, height, mesh));
+    copy->setSelected(isSelected());
+    copy->setVisible(isVisible());
+    copy->setHidden(isHidden());
+    return copy;
+}

--- a/src/GeometryKernel/Solid.h
+++ b/src/GeometryKernel/Solid.h
@@ -15,6 +15,7 @@ public:
     ObjectType getType() const override { return ObjectType::Solid; }
     const HalfEdgeMesh& getMesh() const override { return mesh; }
     HalfEdgeMesh& getMesh() override { return mesh; }
+    std::unique_ptr<GeometryObject> clone() const override;
 
     const std::vector<Vector3>& getBaseLoop() const { return baseLoop; }
     float getHeight() const { return height; }

--- a/src/Scene/Document.cpp
+++ b/src/Scene/Document.cpp
@@ -2,11 +2,425 @@
 
 #include "SectionPlane.h"
 #include "SceneSettings.h"
+#include "../CameraController.h"
 
+#include <algorithm>
 #include <fstream>
-#include <string>
+#include <iomanip>
+#include <limits>
+#include <queue>
+#include <sstream>
+#include <utility>
+
+namespace {
+constexpr const char* kBeginGeometry = "BEGIN_GEOMETRY";
+constexpr const char* kEndGeometry = "END_GEOMETRY";
+constexpr const char* kBeginSectionPlanes = "BEGIN_SECTION_PLANES";
+constexpr const char* kEndSectionPlanes = "END_SECTION_PLANES";
+constexpr const char* kBeginSettings = "BEGIN_SETTINGS";
+constexpr const char* kEndSettings = "END_SETTINGS";
+constexpr const char* kBeginObjectTree = "BEGIN_OBJECT_TREE";
+constexpr const char* kEndObjectTree = "END_OBJECT_TREE";
+constexpr const char* kBeginTags = "BEGIN_TAGS";
+constexpr const char* kEndTags = "END_TAGS";
+constexpr const char* kBeginComponentDefs = "BEGIN_COMPONENT_DEFS";
+constexpr const char* kEndComponentDefs = "END_COMPONENT_DEFS";
+constexpr const char* kBeginScenes = "BEGIN_SCENES";
+constexpr const char* kEndScenes = "END_SCENES";
+constexpr const char* kColorByTagToken = "COLOR_BY_TAG";
+
+template <typename Container, typename Value>
+bool contains(const Container& container, const Value& value)
+{
+    return std::find(container.begin(), container.end(), value) != container.end();
+}
+
+} // namespace
 
 namespace Scene {
+
+Document::Document()
+{
+    rootNode = std::make_unique<ObjectNode>();
+    rootNode->id = 0;
+    rootNode->kind = NodeKind::Root;
+    rootNode->name = "Root";
+    rootNode->visible = true;
+    registerNode(rootNode.get());
+}
+
+const Document::ObjectNode* Document::findObject(ObjectId id) const
+{
+    return findConst(id);
+}
+
+Document::ObjectNode* Document::findObject(ObjectId id)
+{
+    return findMutable(id);
+}
+
+Document::ObjectId Document::ensureObjectForGeometry(GeometryObject* object, const std::string& name)
+{
+    if (!object)
+        return 0;
+    auto it = geometryIndex.find(object);
+    if (it != geometryIndex.end())
+        return it->second;
+
+    std::string nodeName = name.empty() ? std::string("Object ") + std::to_string(nextObjectId) : name;
+    ObjectNode* node = addNode(NodeKind::Geometry, nodeName, rootNode.get());
+    node->geometry = object;
+    registerGeometry(node, object);
+    updateVisibility();
+    return node->id;
+}
+
+void Document::synchronizeWithGeometry()
+{
+    std::unordered_set<const GeometryObject*> existing;
+    existing.reserve(geometryKernel.getObjects().size());
+    for (const auto& uptr : geometryKernel.getObjects()) {
+        existing.insert(uptr.get());
+    }
+
+    std::vector<ObjectId> toRemove;
+    for (const auto& [geometryPtr, objectId] : geometryIndex) {
+        if (!existing.count(geometryPtr)) {
+            toRemove.push_back(objectId);
+        }
+    }
+    for (ObjectId id : toRemove) {
+        if (ObjectNode* node = findMutable(id)) {
+            removeNode(node);
+        }
+    }
+
+    for (const auto& uptr : geometryKernel.getObjects()) {
+        ensureObjectForGeometry(uptr.get());
+    }
+}
+
+void Document::pruneInvalidObjects()
+{
+    synchronizeWithGeometry();
+}
+
+Document::ObjectId Document::createGroup(const std::vector<ObjectId>& childIds, const std::string& name)
+{
+    if (childIds.empty())
+        return 0;
+
+    std::vector<ObjectNode*> children;
+    children.reserve(childIds.size());
+    for (ObjectId id : childIds) {
+        ObjectNode* node = findMutable(id);
+        if (!node || node == rootNode.get())
+            return 0;
+        children.push_back(node);
+    }
+
+    ObjectNode* firstParent = children.front()->parent ? children.front()->parent : rootNode.get();
+    for (ObjectNode* child : children) {
+        if (!child->parent)
+            continue;
+        if (child->parent != firstParent) {
+            firstParent = rootNode.get();
+            break;
+        }
+    }
+
+    ObjectNode* group = addNode(NodeKind::Group, name.empty() ? std::string("Group ") + std::to_string(nextObjectId) : name, firstParent);
+
+    for (ObjectNode* child : children) {
+        std::unique_ptr<ObjectNode> owned = detachChild(child);
+        if (!owned)
+            continue;
+        owned->parent = group;
+        group->children.push_back(std::move(owned));
+    }
+
+    updateVisibility();
+    return group->id;
+}
+
+bool Document::moveObject(ObjectId objectId, ObjectId newParentId, std::size_t index)
+{
+    ObjectNode* node = findMutable(objectId);
+    ObjectNode* newParent = findMutable(newParentId);
+    if (!node || !newParent || node == rootNode.get())
+        return false;
+    if (node == newParent)
+        return false;
+    if (newParent->kind == NodeKind::Geometry)
+        return false;
+    if (isDescendantOf(*newParent, *node))
+        return false;
+
+    std::unique_ptr<ObjectNode> owned = detachChild(node);
+    if (!owned)
+        return false;
+    owned->parent = newParent;
+    auto& children = newParent->children;
+    index = std::min<std::size_t>(index, children.size());
+    children.insert(children.begin() + static_cast<std::ptrdiff_t>(index), std::move(owned));
+    updateVisibility();
+    return true;
+}
+
+bool Document::setObjectVisible(ObjectId objectId, bool visible)
+{
+    ObjectNode* node = findMutable(objectId);
+    if (!node)
+        return false;
+    node->visible = visible;
+    updateVisibility();
+    return true;
+}
+
+Document::ComponentDefinitionId Document::createComponentDefinition(const std::vector<ObjectId>& sourceIds, const std::string& name)
+{
+    if (sourceIds.empty())
+        return 0;
+
+    ComponentDefinition definition;
+    definition.id = nextDefinitionId++;
+    definition.name = name;
+
+    for (ObjectId id : sourceIds) {
+        const ObjectNode* node = findConst(id);
+        if (!node)
+            continue;
+        definition.roots.push_back(buildPrototypeFromNode(*node, definition));
+    }
+
+    if (definition.roots.empty())
+        return 0;
+
+    componentDefinitions.emplace(definition.id, std::move(definition));
+    return definition.id;
+}
+
+Document::ObjectId Document::instantiateComponent(ComponentDefinitionId definitionId, const std::string& name)
+{
+    auto it = componentDefinitions.find(definitionId);
+    if (it == componentDefinitions.end())
+        return 0;
+
+    ComponentDefinition& definition = it->second;
+    ObjectNode* instance = addNode(NodeKind::ComponentInstance,
+                                   name.empty() ? (!definition.name.empty() ? definition.name : std::string("Component ") + std::to_string(nextObjectId)) : name,
+                                   rootNode.get());
+    instance->definitionId = definitionId;
+    registerNode(instance);
+
+    for (const auto& proto : definition.roots) {
+        instance->children.push_back(instantiatePrototype(*proto, definition, instance));
+    }
+    updateVisibility();
+    return instance->id;
+}
+
+bool Document::makeComponentUnique(ObjectId instanceId)
+{
+    ObjectNode* instance = findMutable(instanceId);
+    if (!instance || instance->kind != NodeKind::ComponentInstance)
+        return false;
+    auto defIt = componentDefinitions.find(instance->definitionId);
+    if (defIt == componentDefinitions.end())
+        return false;
+
+    ComponentDefinition newDefinition;
+    newDefinition.id = nextDefinitionId++;
+    newDefinition.name = instance->name.empty() ? defIt->second.name : instance->name;
+
+    for (const auto& child : instance->children) {
+        newDefinition.roots.push_back(buildPrototypeFromNode(*child, newDefinition));
+    }
+
+    ComponentDefinitionId newId = newDefinition.id;
+    componentDefinitions.emplace(newId, std::move(newDefinition));
+
+    auto& oldInstances = componentInstances[instance->definitionId];
+    oldInstances.erase(std::remove(oldInstances.begin(), oldInstances.end(), instanceId), oldInstances.end());
+    if (oldInstances.empty()) {
+        componentInstances.erase(instance->definitionId);
+    }
+
+    instance->definitionId = newId;
+    registerNode(instance);
+    return true;
+}
+
+void Document::refreshComponentInstances(ComponentDefinitionId definitionId)
+{
+    auto defIt = componentDefinitions.find(definitionId);
+    if (defIt == componentDefinitions.end())
+        return;
+
+    auto instIt = componentInstances.find(definitionId);
+    if (instIt == componentInstances.end())
+        return;
+
+    for (ObjectId id : instIt->second) {
+        ObjectNode* instance = findMutable(id);
+        if (!instance)
+            continue;
+        removeChildGeometry(*instance);
+        instance->children.clear();
+        for (const auto& proto : defIt->second.roots) {
+            instance->children.push_back(instantiatePrototype(*proto, defIt->second, instance));
+        }
+    }
+    updateVisibility();
+}
+
+Document::TagId Document::createTag(const std::string& name, const SceneSettings::Color& color)
+{
+    Tag tag;
+    tag.id = nextTagId++;
+    tag.name = name;
+    tag.color = color;
+    tag.visible = true;
+    tagMap.emplace(tag.id, tag);
+    return tag.id;
+}
+
+bool Document::renameTag(TagId id, const std::string& name)
+{
+    auto it = tagMap.find(id);
+    if (it == tagMap.end())
+        return false;
+    it->second.name = name;
+    return true;
+}
+
+bool Document::setTagColor(TagId id, const SceneSettings::Color& color)
+{
+    auto it = tagMap.find(id);
+    if (it == tagMap.end())
+        return false;
+    it->second.color = color;
+    return true;
+}
+
+bool Document::setTagVisible(TagId id, bool visible)
+{
+    auto it = tagMap.find(id);
+    if (it == tagMap.end())
+        return false;
+    it->second.visible = visible;
+    updateVisibility();
+    return true;
+}
+
+bool Document::assignTag(ObjectId objectId, TagId tagId)
+{
+    ObjectNode* node = findMutable(objectId);
+    if (!node || tagMap.find(tagId) == tagMap.end())
+        return false;
+    if (!contains(node->tags, tagId)) {
+        node->tags.push_back(tagId);
+        updateVisibility();
+    }
+    return true;
+}
+
+bool Document::removeTag(ObjectId objectId, TagId tagId)
+{
+    ObjectNode* node = findMutable(objectId);
+    if (!node)
+        return false;
+    auto it = std::remove(node->tags.begin(), node->tags.end(), tagId);
+    if (it == node->tags.end())
+        return false;
+    node->tags.erase(it, node->tags.end());
+    updateVisibility();
+    return true;
+}
+
+void Document::setColorByTag(bool enabled)
+{
+    colorByTagEnabled = enabled;
+}
+
+void Document::isolate(ObjectId objectId)
+{
+    isolationIds.clear();
+    if (findConst(objectId)) {
+        isolationIds.push_back(objectId);
+    }
+    updateVisibility();
+}
+
+void Document::pushIsolation(ObjectId objectId)
+{
+    if (!findConst(objectId))
+        return;
+    isolationIds.push_back(objectId);
+    updateVisibility();
+}
+
+void Document::clearIsolation()
+{
+    if (isolationIds.empty())
+        return;
+    isolationIds.clear();
+    updateVisibility();
+}
+
+Document::SceneId Document::createScene(const std::string& name, const CameraController& camera)
+{
+    SceneState state;
+    state.id = nextSceneId++;
+    state.name = name;
+    state.settings = sceneSettings;
+    state.colorByTag = colorByTagEnabled;
+    for (const auto& [id, tag] : tagMap) {
+        state.tagVisibility[id] = tag.visible;
+    }
+    captureSceneState(camera, state);
+    sceneMap.emplace(state.id, state);
+    return state.id;
+}
+
+bool Document::updateScene(SceneId id, const CameraController& camera)
+{
+    auto it = sceneMap.find(id);
+    if (it == sceneMap.end())
+        return false;
+    it->second.settings = sceneSettings;
+    it->second.colorByTag = colorByTagEnabled;
+    it->second.tagVisibility.clear();
+    for (const auto& [tagId, tag] : tagMap) {
+        it->second.tagVisibility[tagId] = tag.visible;
+    }
+    captureSceneState(camera, it->second);
+    return true;
+}
+
+bool Document::applyScene(SceneId id, CameraController& camera)
+{
+    auto it = sceneMap.find(id);
+    if (it == sceneMap.end())
+        return false;
+    const SceneState& state = it->second;
+    sceneSettings = state.settings;
+    colorByTagEnabled = state.colorByTag;
+    for (auto& [tagId, tag] : tagMap) {
+        auto visIt = state.tagVisibility.find(tagId);
+        if (visIt != state.tagVisibility.end()) {
+            tag.visible = visIt->second;
+        }
+    }
+    applySceneState(state, camera);
+    updateVisibility();
+    return true;
+}
+
+bool Document::removeScene(SceneId id)
+{
+    return sceneMap.erase(id) > 0;
+}
 
 SectionPlane& Document::addSectionPlane(const SectionPlane& plane)
 {
@@ -24,82 +438,821 @@ void Document::reset()
     geometryKernel.clear();
     planes.clear();
     sceneSettings.reset();
+    rootNode = std::make_unique<ObjectNode>();
+    rootNode->id = 0;
+    rootNode->kind = NodeKind::Root;
+    rootNode->name = "Root";
+    nodeIndex.clear();
+    geometryIndex.clear();
+    componentDefinitions.clear();
+    componentInstances.clear();
+    sceneMap.clear();
+    tagMap.clear();
+    colorByTagEnabled = false;
+    isolationIds.clear();
+    nextObjectId = 1;
+    nextTagId = 1;
+    nextDefinitionId = 1;
+    nextSceneId = 1;
+    registerNode(rootNode.get());
 }
 
 bool Document::saveToFile(const std::string& filename) const
 {
     std::ofstream os(filename, std::ios::out | std::ios::trunc);
-    if (!os) {
+    if (!os)
         return false;
-    }
-    os << "FCM 3\n";
-    os << "BEGIN_GEOMETRY\n";
-    geometryKernel.saveToStream(os);
-    os << "END_GEOMETRY\n";
 
-    os << "BEGIN_SECTION_PLANES " << planes.size() << "\n";
+    os << "FCM 4\n";
+    os << kBeginGeometry << '\n';
+    geometryKernel.saveToStream(os);
+    os << kEndGeometry << '\n';
+
+    os << kBeginSectionPlanes << ' ' << planes.size() << '\n';
     for (const auto& plane : planes) {
         plane.serialize(os);
     }
-    os << "END_SECTION_PLANES\n";
+    os << kEndSectionPlanes << '\n';
 
-    os << "BEGIN_SETTINGS\n";
+    os << kBeginSettings << '\n';
     sceneSettings.serialize(os);
-    os << "END_SETTINGS\n";
+    os << kEndSettings << '\n';
+
+    serializeTags(os);
+    serializeObjectTree(os);
+    serializeComponentDefinitions(os);
+    serializeScenes(os);
+    os << kColorByTagToken << ' ' << (colorByTagEnabled ? 1 : 0) << '\n';
     return true;
 }
 
 bool Document::loadFromFile(const std::string& filename)
 {
     std::ifstream is(filename);
-    if (!is) {
+    if (!is)
         return false;
-    }
+
     std::string tag;
     int version = 0;
-    if (!(is >> tag >> version)) {
+    if (!(is >> tag >> version))
         return false;
-    }
-    if (tag != "FCM") {
+    if (tag != "FCM")
         return false;
-    }
 
     if (version <= 1) {
         bool loaded = geometryKernel.loadFromFile(filename);
-        planes.clear();
-        sceneSettings.reset();
+        reset();
+        synchronizeWithGeometry();
         return loaded;
     }
 
     geometryKernel.clear();
     planes.clear();
     sceneSettings.reset();
+    tagMap.clear();
+    componentDefinitions.clear();
+    componentInstances.clear();
+    sceneMap.clear();
+    colorByTagEnabled = false;
+    isolationIds.clear();
+    nodeIndex.clear();
+    geometryIndex.clear();
+    rootNode = std::make_unique<ObjectNode>();
+    rootNode->id = 0;
+    rootNode->kind = NodeKind::Root;
+    rootNode->name = "Root";
+    nextObjectId = 1;
+    nextTagId = 1;
+    nextDefinitionId = 1;
+    nextSceneId = 1;
+    registerNode(rootNode.get());
 
     std::string token;
     while (is >> token) {
-        if (token == "BEGIN_GEOMETRY") {
-            geometryKernel.loadFromStream(is, "END_GEOMETRY");
-        } else if (token == "BEGIN_SECTION_PLANES") {
+        if (token == kBeginGeometry) {
+            geometryKernel.loadFromStream(is, kEndGeometry);
+        } else if (token == kBeginSectionPlanes) {
             size_t count = 0;
             is >> count;
             planes.clear();
             planes.reserve(count);
             for (size_t i = 0; i < count; ++i) {
                 SectionPlane plane;
-                if (!plane.deserialize(is)) {
+                if (!plane.deserialize(is))
                     break;
-                }
                 planes.push_back(plane);
             }
-        } else if (token == "END_SECTION_PLANES") {
-            continue;
-        } else if (token == "BEGIN_SETTINGS") {
+        } else if (token == kBeginSettings) {
             sceneSettings.deserialize(is, version);
-        } else if (token == "END_SETTINGS" || token == "END_GEOMETRY") {
-            continue;
+        } else if (token == kBeginTags) {
+            if (!deserializeTags(is))
+                return false;
+        } else if (token == kBeginObjectTree) {
+            std::vector<GeometryObject*> geometryObjects;
+            geometryObjects.reserve(geometryKernel.getObjects().size());
+            for (const auto& uptr : geometryKernel.getObjects()) {
+                geometryObjects.push_back(uptr.get());
+            }
+            if (!deserializeObjectTree(is, version, geometryObjects))
+                return false;
+        } else if (token == kBeginComponentDefs) {
+            if (!deserializeComponentDefinitions(is, version))
+                return false;
+        } else if (token == kBeginScenes) {
+            if (!deserializeScenes(is, version))
+                return false;
+        } else if (token == kColorByTagToken) {
+            int enabled = 0;
+            is >> enabled;
+            colorByTagEnabled = enabled != 0;
+        }
+    }
+
+    synchronizeWithGeometry();
+    updateVisibility();
+    return true;
+}
+
+void Document::removeNode(ObjectNode* node)
+{
+    if (!node || node == rootNode.get())
+        return;
+    while (!node->children.empty()) {
+        removeNode(node->children.back().get());
+    }
+    if (node->geometry) {
+        GeometryObject* geom = node->geometry;
+        unregisterGeometry(geom);
+        geometryKernel.deleteObject(geom);
+        node->geometry = nullptr;
+    }
+    unregisterNode(node);
+    detachFromParent(node);
+}
+
+void Document::removeChildGeometry(ObjectNode& node)
+{
+    while (!node.children.empty()) {
+        removeNode(node.children.back().get());
+    }
+}
+
+void Document::forEachNode(const std::function<void(ObjectNode&)>& fn)
+{
+    std::queue<ObjectNode*> queue;
+    queue.push(rootNode.get());
+    while (!queue.empty()) {
+        ObjectNode* node = queue.front();
+        queue.pop();
+        fn(*node);
+        for (auto& child : node->children) {
+            queue.push(child.get());
+        }
+    }
+}
+
+void Document::forEachNode(const std::function<void(const ObjectNode&)>& fn) const
+{
+    std::queue<const ObjectNode*> queue;
+    queue.push(rootNode.get());
+    while (!queue.empty()) {
+        const ObjectNode* node = queue.front();
+        queue.pop();
+        fn(*node);
+        for (const auto& child : node->children) {
+            queue.push(child.get());
+        }
+    }
+}
+
+void Document::rebuildIndices()
+{
+    nodeIndex.clear();
+    geometryIndex.clear();
+    componentInstances.clear();
+    forEachNode([&](ObjectNode& node) {
+        if (node.id == 0)
+            return;
+        registerNode(&node);
+        if (node.geometry) {
+            registerGeometry(&node, node.geometry);
+        }
+    });
+}
+
+void Document::updateVisibility()
+{
+    std::unordered_set<TagId> hiddenTags;
+    for (const auto& [id, tag] : tagMap) {
+        if (!tag.visible)
+            hiddenTags.insert(id);
+    }
+
+    std::unordered_set<ObjectId> isolationSet;
+    if (!isolationIds.empty()) {
+        for (ObjectId id : isolationIds) {
+            const ObjectNode* node = findConst(id);
+            if (!node)
+                continue;
+            const ObjectNode* current = node;
+            while (current) {
+                isolationSet.insert(current->id);
+                current = current->parent;
+            }
+            collectIsolationIds(*node, isolationSet);
+        }
+    }
+
+    applyVisibilityRecursive(*rootNode, hiddenTags, isolationSet, true);
+}
+
+void Document::applyVisibilityRecursive(ObjectNode& node, const std::unordered_set<TagId>& hiddenTags,
+                                        const std::unordered_set<ObjectId>& isolatedIds, bool ancestorVisible)
+{
+    bool nodeVisible = ancestorVisible && node.visible;
+    bool isolationActive = !isolatedIds.empty();
+    bool nodeAllowed = !isolationActive || isolatedIds.count(node.id) > 0 || node.kind == NodeKind::Root;
+
+    if (node.kind == NodeKind::Geometry && node.geometry) {
+        bool hidden = !(nodeVisible && nodeAllowed);
+        if (!hidden) {
+            for (TagId tagId : node.tags) {
+                if (hiddenTags.count(tagId)) {
+                    hidden = true;
+                    break;
+                }
+            }
+        }
+        node.geometry->setHidden(hidden);
+        node.geometry->setVisible(!hidden);
+    }
+
+    bool passToChildren = nodeVisible && nodeAllowed;
+    for (auto& child : node.children) {
+        applyVisibilityRecursive(*child, hiddenTags, isolatedIds, passToChildren);
+    }
+}
+
+void Document::collectIsolationIds(const ObjectNode& node, std::unordered_set<ObjectId>& ids) const
+{
+    ids.insert(node.id);
+    for (const auto& child : node.children) {
+        collectIsolationIds(*child, ids);
+    }
+}
+
+Document::ObjectNode* Document::findMutable(ObjectId id)
+{
+    auto it = nodeIndex.find(id);
+    if (it == nodeIndex.end())
+        return nullptr;
+    return it->second;
+}
+
+const Document::ObjectNode* Document::findConst(ObjectId id) const
+{
+    auto it = nodeIndex.find(id);
+    if (it == nodeIndex.end())
+        return nullptr;
+    return it->second;
+}
+
+bool Document::isDescendantOf(const ObjectNode& node, const ObjectNode& ancestor) const
+{
+    const ObjectNode* current = node.parent;
+    while (current) {
+        if (current == &ancestor)
+            return true;
+        current = current->parent;
+    }
+    return false;
+}
+
+std::unique_ptr<Document::PrototypeNode> Document::buildPrototypeFromNode(const ObjectNode& node, ComponentDefinition& definition)
+{
+    auto prototype = std::make_unique<PrototypeNode>();
+    prototype->kind = (node.kind == NodeKind::ComponentInstance) ? NodeKind::Group : node.kind;
+    prototype->name = node.name;
+    prototype->tags = node.tags;
+    if (node.kind == NodeKind::Geometry && node.geometry) {
+        std::unique_ptr<GeometryObject> clone = node.geometry->clone();
+        prototype->geometry = definition.geometry.addObject(std::move(clone));
+    }
+    for (const auto& child : node.children) {
+        prototype->children.push_back(buildPrototypeFromNode(*child, definition));
+    }
+    return prototype;
+}
+
+std::unique_ptr<Document::ObjectNode> Document::instantiatePrototype(const PrototypeNode& proto, ComponentDefinition& definition, ObjectNode* parent)
+{
+    auto node = std::make_unique<ObjectNode>();
+    node->id = nextObjectId++;
+    node->kind = proto.kind;
+    node->name = proto.name;
+    node->parent = parent;
+    node->tags = proto.tags;
+    node->visible = true;
+    node->expanded = true;
+
+    if (proto.kind == NodeKind::Geometry && proto.geometry) {
+        std::unique_ptr<GeometryObject> clone = proto.geometry->clone();
+        GeometryObject* added = geometryKernel.addObject(std::move(clone));
+        node->geometry = added;
+        registerGeometry(node.get(), added);
+    }
+
+    for (const auto& child : proto.children) {
+        node->children.push_back(instantiatePrototype(*child, definition, node.get()));
+    }
+
+    registerNode(node.get());
+    return node;
+}
+
+void Document::registerNode(ObjectNode* node)
+{
+    if (!node)
+        return;
+    nodeIndex[node->id] = node;
+    if (node->kind == NodeKind::ComponentInstance && node->definitionId != 0) {
+        auto& instances = componentInstances[node->definitionId];
+        if (!contains(instances, node->id)) {
+            instances.push_back(node->id);
+        }
+    }
+}
+
+void Document::unregisterNode(ObjectNode* node)
+{
+    if (!node)
+        return;
+    nodeIndex.erase(node->id);
+    if (node->kind == NodeKind::ComponentInstance) {
+        auto it = componentInstances.find(node->definitionId);
+        if (it != componentInstances.end()) {
+            auto& instances = it->second;
+            instances.erase(std::remove(instances.begin(), instances.end(), node->id), instances.end());
+            if (instances.empty()) {
+                componentInstances.erase(it);
+            }
+        }
+    }
+}
+
+void Document::registerGeometry(ObjectNode* node, GeometryObject* geometry)
+{
+    if (!node || !geometry)
+        return;
+    geometryIndex[geometry] = node->id;
+}
+
+void Document::unregisterGeometry(GeometryObject* geometry)
+{
+    if (!geometry)
+        return;
+    geometryIndex.erase(geometry);
+}
+
+void Document::detachFromParent(ObjectNode* node)
+{
+    if (!node || !node->parent)
+        return;
+    auto& children = node->parent->children;
+    for (auto it = children.begin(); it != children.end(); ++it) {
+        if (it->get() == node) {
+            children.erase(it);
+            break;
+        }
+    }
+}
+
+std::unique_ptr<Document::ObjectNode> Document::detachChild(ObjectNode* node)
+{
+    if (!node || !node->parent)
+        return nullptr;
+    auto& children = node->parent->children;
+    for (auto it = children.begin(); it != children.end(); ++it) {
+        if (it->get() == node) {
+            std::unique_ptr<ObjectNode> owned = std::move(*it);
+            children.erase(it);
+            owned->parent = nullptr;
+            return owned;
+        }
+    }
+    return nullptr;
+}
+
+void Document::captureSceneState(const CameraController& camera, SceneState& state) const
+{
+    state.camera.yaw = camera.getYaw();
+    state.camera.pitch = camera.getPitch();
+    state.camera.distance = camera.getDistance();
+    float tx = 0.0f, ty = 0.0f, tz = 0.0f;
+    camera.getTarget(tx, ty, tz);
+    state.camera.target = Vector3(tx, ty, tz);
+    state.camera.projection = camera.getProjectionMode();
+    state.camera.fieldOfView = camera.getFieldOfView();
+    state.camera.orthoHeight = camera.getOrthoHeight();
+}
+
+void Document::applySceneState(const SceneState& state, CameraController& camera)
+{
+    camera.setProjectionMode(state.camera.projection);
+    camera.setTarget(state.camera.target.x, state.camera.target.y, state.camera.target.z);
+    camera.setYawPitch(state.camera.yaw, state.camera.pitch);
+    camera.setDistance(state.camera.distance);
+    camera.setFieldOfView(state.camera.fieldOfView);
+    camera.setOrthoHeight(state.camera.orthoHeight);
+}
+
+Document::ObjectNode* Document::addNode(NodeKind kind, const std::string& name, ObjectNode* parent)
+{
+    if (!parent)
+        parent = rootNode.get();
+    auto node = std::make_unique<ObjectNode>();
+    node->id = nextObjectId++;
+    node->kind = kind;
+    node->name = name;
+    node->parent = parent;
+    node->visible = true;
+    node->expanded = true;
+    ObjectNode* raw = node.get();
+    parent->children.push_back(std::move(node));
+    registerNode(raw);
+    return raw;
+}
+
+void Document::serializeObjectTree(std::ostream& os) const
+{
+    std::unordered_map<const GeometryObject*, std::size_t> geometryLookup;
+    const auto& objects = geometryKernel.getObjects();
+    for (std::size_t i = 0; i < objects.size(); ++i) {
+        geometryLookup[objects[i].get()] = i;
+    }
+
+    os << kBeginObjectTree << '\n';
+    serializeNode(os, *rootNode, geometryLookup);
+    os << kEndObjectTree << '\n';
+}
+
+void Document::serializeNode(std::ostream& os, const ObjectNode& node,
+                             const std::unordered_map<const GeometryObject*, std::size_t>& geometryLookup) const
+{
+    if (&node != rootNode.get()) {
+        std::size_t geometryIndexValue = std::numeric_limits<std::size_t>::max();
+        if (node.geometry) {
+            auto it = geometryLookup.find(node.geometry);
+            if (it != geometryLookup.end()) {
+                geometryIndexValue = it->second;
+            }
+        }
+        os << "NODE " << node.id << ' ' << static_cast<int>(node.kind) << ' ' << std::quoted(node.name)
+           << ' ' << geometryIndexValue << ' ' << node.definitionId << ' ' << (node.visible ? 1 : 0)
+           << ' ' << (node.expanded ? 1 : 0) << ' ' << node.tags.size();
+        for (TagId tagId : node.tags) {
+            os << ' ' << tagId;
+        }
+        os << ' ' << node.children.size() << '\n';
+    }
+
+    for (const auto& child : node.children) {
+        serializeNode(os, *child, geometryLookup);
+    }
+}
+
+bool Document::deserializeObjectTree(std::istream& is, int version, const std::vector<GeometryObject*>& geometryObjects)
+{
+    (void)version;
+    rootNode->children.clear();
+    nodeIndex.clear();
+    geometryIndex.clear();
+    registerNode(rootNode.get());
+
+    std::string token;
+    while (is >> token) {
+        if (token == kEndObjectTree)
+            break;
+        if (token == "NODE") {
+            if (!deserializeNode(is, rootNode.get(), geometryObjects, version))
+                return false;
         }
     }
     return true;
 }
 
+bool Document::deserializeNode(std::istream& is, ObjectNode* parent, const std::vector<GeometryObject*>& geometryObjects, int version)
+{
+    ObjectId id = 0;
+    int kindValue = 0;
+    std::string name;
+    std::size_t geometryIndexValue = std::numeric_limits<std::size_t>::max();
+    ComponentDefinitionId definitionId = 0;
+    int visible = 1;
+    int expanded = 1;
+    std::size_t tagCount = 0;
+    std::size_t childCount = 0;
+
+    if (!(is >> id >> kindValue >> std::quoted(name) >> geometryIndexValue >> definitionId >> visible >> expanded >> tagCount))
+        return false;
+
+    auto node = std::make_unique<ObjectNode>();
+    node->id = id;
+    node->kind = static_cast<NodeKind>(kindValue);
+    node->name = name;
+    node->parent = parent;
+    node->visible = visible != 0;
+    node->expanded = expanded != 0;
+
+    node->tags.reserve(tagCount);
+    for (std::size_t i = 0; i < tagCount; ++i) {
+        TagId tagId = 0;
+        is >> tagId;
+        node->tags.push_back(tagId);
+    }
+    if (!(is >> childCount))
+        return false;
+
+    if (geometryIndexValue < geometryObjects.size()) {
+        node->geometry = geometryObjects[geometryIndexValue];
+        registerGeometry(node.get(), node->geometry);
+    }
+    if (node->kind == NodeKind::ComponentInstance) {
+        node->definitionId = definitionId;
+    }
+
+    ObjectNode* raw = node.get();
+    parent->children.push_back(std::move(node));
+    registerNode(raw);
+    nextObjectId = std::max(nextObjectId, raw->id + 1);
+
+    for (std::size_t i = 0; i < childCount; ++i) {
+        std::string childToken;
+        if (!(is >> childToken) || childToken != "NODE")
+            return false;
+        if (!deserializeNode(is, raw, geometryObjects, version))
+            return false;
+    }
+    return true;
+}
+
+void Document::serializeTags(std::ostream& os) const
+{
+    os << kBeginTags << ' ' << tagMap.size() << '\n';
+    for (const auto& [id, tag] : tagMap) {
+        os << "TAG " << id << ' ' << std::quoted(tag.name) << ' '
+           << tag.color.r << ' ' << tag.color.g << ' ' << tag.color.b << ' ' << tag.color.a
+           << ' ' << (tag.visible ? 1 : 0) << '\n';
+    }
+    os << kEndTags << '\n';
+}
+
+bool Document::deserializeTags(std::istream& is)
+{
+    size_t count = 0;
+    if (!(is >> count))
+        return false;
+    tagMap.clear();
+    for (size_t i = 0; i < count; ++i) {
+        std::string token;
+        if (!(is >> token) || token != "TAG")
+            return false;
+        Tag tag;
+        if (!(is >> tag.id >> std::quoted(tag.name) >> tag.color.r >> tag.color.g >> tag.color.b >> tag.color.a))
+            return false;
+        int visible = 1;
+        is >> visible;
+        tag.visible = visible != 0;
+        tagMap.emplace(tag.id, tag);
+        nextTagId = std::max(nextTagId, tag.id + 1);
+    }
+    std::string endToken;
+    if (!(is >> endToken) || endToken != kEndTags)
+        return false;
+    return true;
+}
+
+void Document::serializeComponentDefinitions(std::ostream& os) const
+{
+    os << kBeginComponentDefs << ' ' << componentDefinitions.size() << '\n';
+    for (const auto& [id, definition] : componentDefinitions) {
+        os << "DEF " << id << ' ' << std::quoted(definition.name) << '\n';
+        os << "DEF_GEOMETRY\n";
+        definition.geometry.saveToStream(os);
+        os << "END_DEF_GEOMETRY\n";
+
+        std::unordered_map<const GeometryObject*, std::size_t> lookup;
+        const auto& objects = definition.geometry.getObjects();
+        for (std::size_t i = 0; i < objects.size(); ++i) {
+            lookup[objects[i].get()] = i;
+        }
+
+        std::function<void(const PrototypeNode&)> serializeProto = [&](const PrototypeNode& proto) {
+            os << "PROTO " << static_cast<int>(proto.kind) << ' ' << std::quoted(proto.name) << ' ';
+            std::size_t geometryIndexValue = std::numeric_limits<std::size_t>::max();
+            if (proto.geometry) {
+                auto it = lookup.find(proto.geometry);
+                if (it != lookup.end()) {
+                    geometryIndexValue = it->second;
+                }
+            }
+            os << geometryIndexValue << ' ' << proto.tags.size();
+            for (TagId tagId : proto.tags) {
+                os << ' ' << tagId;
+            }
+            os << ' ' << proto.children.size() << '\n';
+            for (const auto& child : proto.children) {
+                serializeProto(*child);
+            }
+            os << "END_PROTO\n";
+        };
+
+        os << "BEGIN_PROTOTYPES\n";
+        for (const auto& proto : definition.roots) {
+            serializeProto(*proto);
+        }
+        os << "END_PROTOTYPES\n";
+    }
+    os << kEndComponentDefs << '\n';
+}
+
+bool Document::deserializeComponentDefinitions(std::istream& is, int version)
+{
+    (void)version;
+    size_t count = 0;
+    if (!(is >> count))
+        return false;
+    componentDefinitions.clear();
+    componentInstances.clear();
+    for (size_t i = 0; i < count; ++i) {
+        std::string token;
+        if (!(is >> token) || token != "DEF")
+            return false;
+        ComponentDefinition definition;
+        if (!(is >> definition.id >> std::quoted(definition.name)))
+            return false;
+        nextDefinitionId = std::max(nextDefinitionId, definition.id + 1);
+
+        std::string geometryToken;
+        if (!(is >> geometryToken) || geometryToken != "DEF_GEOMETRY")
+            return false;
+        definition.geometry.loadFromStream(is, "END_DEF_GEOMETRY");
+
+        std::vector<GeometryObject*> geometryObjects;
+        const auto& objects = definition.geometry.getObjects();
+        geometryObjects.reserve(objects.size());
+        for (const auto& uptr : objects) {
+            geometryObjects.push_back(uptr.get());
+        }
+
+        std::string protoToken;
+        if (!(is >> protoToken) || protoToken != "BEGIN_PROTOTYPES")
+            return false;
+
+        while (true) {
+            if (!(is >> protoToken))
+                return false;
+            if (protoToken == "END_PROTOTYPES")
+                break;
+            if (protoToken != "PROTO")
+                return false;
+            auto proto = std::make_unique<PrototypeNode>();
+            if (!parsePrototype(is, geometryObjects, *proto))
+                return false;
+            std::string endToken;
+            if (!(is >> endToken) || endToken != "END_PROTO")
+                return false;
+            definition.roots.push_back(std::move(proto));
+        }
+
+        componentDefinitions.emplace(definition.id, std::move(definition));
+    }
+    std::string endToken;
+    if (!(is >> endToken) || endToken != kEndComponentDefs)
+        return false;
+    return true;
+}
+
+void Document::serializeScenes(std::ostream& os) const
+{
+    os << kBeginScenes << ' ' << sceneMap.size() << '\n';
+    for (const auto& [id, scene] : sceneMap) {
+        const auto& palette = scene.settings.palette();
+        os << "SCENE " << id << ' ' << std::quoted(scene.name) << ' '
+           << scene.camera.yaw << ' ' << scene.camera.pitch << ' ' << scene.camera.distance << ' '
+           << scene.camera.target.x << ' ' << scene.camera.target.y << ' ' << scene.camera.target.z << ' '
+           << static_cast<int>(scene.camera.projection) << ' ' << scene.camera.fieldOfView << ' ' << scene.camera.orthoHeight << ' '
+           << (scene.colorByTag ? 1 : 0) << ' ' << (scene.settings.sectionPlanesVisible() ? 1 : 0) << ' '
+           << (scene.settings.sectionFillsVisible() ? 1 : 0) << ' ' << std::quoted(palette.id) << ' '
+           << palette.fill.r << ' ' << palette.fill.g << ' ' << palette.fill.b << ' ' << palette.fill.a << ' '
+           << palette.edge.r << ' ' << palette.edge.g << ' ' << palette.edge.b << ' ' << palette.edge.a << ' '
+           << palette.highlight.r << ' ' << palette.highlight.g << ' ' << palette.highlight.b << ' ' << palette.highlight.a << ' '
+           << scene.tagVisibility.size() << '\n';
+        for (const auto& [tagId, visible] : scene.tagVisibility) {
+            os << "SCENE_TAG " << tagId << ' ' << (visible ? 1 : 0) << '\n';
+        }
+        os << "END_SCENE\n";
+    }
+    os << kEndScenes << '\n';
+}
+
+bool Document::deserializeScenes(std::istream& is, int version)
+{
+    (void)version;
+    size_t count = 0;
+    if (!(is >> count))
+        return false;
+    sceneMap.clear();
+    for (size_t i = 0; i < count; ++i) {
+        std::string token;
+        if (!(is >> token) || token != "SCENE")
+            return false;
+        SceneState scene;
+        int projection = 0;
+        int colorBy = 0;
+        int planesVisible = 1;
+        int fillsVisible = 1;
+        std::string paletteId;
+        std::size_t tagCount = 0;
+        SceneSettings::PaletteState palette;
+        if (!(is >> scene.id >> std::quoted(scene.name) >> scene.camera.yaw >> scene.camera.pitch >> scene.camera.distance
+              >> scene.camera.target.x >> scene.camera.target.y >> scene.camera.target.z >> projection
+              >> scene.camera.fieldOfView >> scene.camera.orthoHeight >> colorBy >> planesVisible >> fillsVisible
+              >> std::quoted(paletteId)
+              >> palette.fill.r >> palette.fill.g >> palette.fill.b >> palette.fill.a
+              >> palette.edge.r >> palette.edge.g >> palette.edge.b >> palette.edge.a
+              >> palette.highlight.r >> palette.highlight.g >> palette.highlight.b >> palette.highlight.a
+              >> tagCount))
+            return false;
+
+        palette.id = paletteId;
+        scene.settings.reset();
+        scene.settings.setPalette(palette);
+        scene.settings.setSectionPlanesVisible(planesVisible != 0);
+        scene.settings.setSectionFillsVisible(fillsVisible != 0);
+        scene.colorByTag = colorBy != 0;
+        scene.camera.projection = static_cast<CameraController::ProjectionMode>(projection);
+
+        for (std::size_t j = 0; j < tagCount; ++j) {
+            std::string tagToken;
+            if (!(is >> tagToken) || tagToken != "SCENE_TAG")
+                return false;
+            TagId tagId = 0;
+            int visible = 1;
+            if (!(is >> tagId >> visible))
+                return false;
+            scene.tagVisibility[tagId] = visible != 0;
+        }
+
+        std::string endScene;
+        if (!(is >> endScene) || endScene != "END_SCENE")
+            return false;
+
+        nextSceneId = std::max(nextSceneId, scene.id + 1);
+        sceneMap.emplace(scene.id, scene);
+    }
+
+    std::string endToken;
+    if (!(is >> endToken) || endToken != kEndScenes)
+        return false;
+    return true;
+}
+
+bool Document::parsePrototype(std::istream& is, const std::vector<GeometryObject*>& geometryObjects, PrototypeNode& proto)
+{
+    int kindValue = 0;
+    std::size_t geometryIndexValue = std::numeric_limits<std::size_t>::max();
+    std::size_t tagCount = 0;
+    std::size_t childCount = 0;
+    if (!(is >> kindValue >> std::quoted(proto.name) >> geometryIndexValue >> tagCount))
+        return false;
+    proto.kind = static_cast<NodeKind>(kindValue);
+    proto.tags.clear();
+    proto.tags.reserve(tagCount);
+    for (std::size_t i = 0; i < tagCount; ++i) {
+        TagId tagId = 0;
+        is >> tagId;
+        proto.tags.push_back(tagId);
+    }
+    if (!(is >> childCount))
+        return false;
+    proto.geometry = geometryIndexValue < geometryObjects.size() ? geometryObjects[geometryIndexValue] : nullptr;
+    proto.children.clear();
+    proto.children.reserve(childCount);
+    for (std::size_t i = 0; i < childCount; ++i) {
+        std::string token;
+        if (!(is >> token) || token != "PROTO")
+            return false;
+        auto child = std::make_unique<PrototypeNode>();
+        if (!parsePrototype(is, geometryObjects, *child))
+            return false;
+        std::string endToken;
+        if (!(is >> endToken) || endToken != "END_PROTO")
+            return false;
+        proto.children.push_back(std::move(child));
+    }
+    return true;
+}
+
 } // namespace Scene
+

--- a/src/Scene/Document.h
+++ b/src/Scene/Document.h
@@ -2,16 +2,74 @@
 
 #include "SectionPlane.h"
 #include "SceneSettings.h"
+#include "../CameraController.h"
 #include "../GeometryKernel/GeometryKernel.h"
 
+#include <iosfwd>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace Scene {
 
 class Document {
 public:
-    Document() = default;
+    enum class NodeKind {
+        Root,
+        Geometry,
+        Group,
+        ComponentInstance
+    };
+
+    using ObjectId = std::uint64_t;
+    using TagId = std::uint64_t;
+    using ComponentDefinitionId = std::uint64_t;
+    using SceneId = std::uint64_t;
+
+    struct ObjectNode {
+        ObjectId id = 0;
+        NodeKind kind = NodeKind::Geometry;
+        std::string name;
+        GeometryObject* geometry = nullptr;
+        ComponentDefinitionId definitionId = 0;
+        ObjectNode* parent = nullptr;
+        std::vector<TagId> tags;
+        bool visible = true;
+        bool expanded = true;
+        std::vector<std::unique_ptr<ObjectNode>> children;
+    };
+
+    struct Tag {
+        TagId id = 0;
+        std::string name;
+        SceneSettings::Color color{};
+        bool visible = true;
+    };
+
+    struct SceneState {
+        struct CameraState {
+            float yaw = 0.0f;
+            float pitch = 0.0f;
+            float distance = 0.0f;
+            Vector3 target{ 0.0f, 0.0f, 0.0f };
+            CameraController::ProjectionMode projection = CameraController::ProjectionMode::Perspective;
+            float fieldOfView = 35.0f;
+            float orthoHeight = 10.0f;
+        };
+
+        SceneId id = 0;
+        std::string name;
+        CameraState camera;
+        SceneSettings settings;
+        bool colorByTag = false;
+        std::unordered_map<TagId, bool> tagVisibility;
+    };
+
+    Document();
 
     GeometryKernel& geometry() { return geometryKernel; }
     const GeometryKernel& geometry() const { return geometryKernel; }
@@ -22,6 +80,44 @@ public:
     SceneSettings& settings() { return sceneSettings; }
     const SceneSettings& settings() const { return sceneSettings; }
 
+    const ObjectNode& objectTree() const { return *rootNode; }
+    const ObjectNode* findObject(ObjectId id) const;
+    ObjectNode* findObject(ObjectId id);
+
+    ObjectId ensureObjectForGeometry(GeometryObject* object, const std::string& name = std::string());
+    void synchronizeWithGeometry();
+    void pruneInvalidObjects();
+
+    ObjectId createGroup(const std::vector<ObjectId>& childIds, const std::string& name);
+    bool moveObject(ObjectId objectId, ObjectId newParentId, std::size_t index);
+    bool setObjectVisible(ObjectId objectId, bool visible);
+
+    ComponentDefinitionId createComponentDefinition(const std::vector<ObjectId>& sourceIds, const std::string& name);
+    ObjectId instantiateComponent(ComponentDefinitionId definitionId, const std::string& name);
+    bool makeComponentUnique(ObjectId instanceId);
+    void refreshComponentInstances(ComponentDefinitionId definitionId);
+
+    TagId createTag(const std::string& name, const SceneSettings::Color& color);
+    bool renameTag(TagId id, const std::string& name);
+    bool setTagColor(TagId id, const SceneSettings::Color& color);
+    bool setTagVisible(TagId id, bool visible);
+    bool assignTag(ObjectId objectId, TagId tagId);
+    bool removeTag(ObjectId objectId, TagId tagId);
+    const std::unordered_map<TagId, Tag>& tags() const { return tagMap; }
+    bool colorByTag() const { return colorByTagEnabled; }
+    void setColorByTag(bool enabled);
+
+    void isolate(ObjectId objectId);
+    void pushIsolation(ObjectId objectId);
+    void clearIsolation();
+    const std::vector<ObjectId>& isolationStack() const { return isolationIds; }
+
+    SceneId createScene(const std::string& name, const CameraController& camera);
+    bool updateScene(SceneId id, const CameraController& camera);
+    bool applyScene(SceneId id, CameraController& camera);
+    bool removeScene(SceneId id);
+    const std::unordered_map<SceneId, SceneState>& scenes() const { return sceneMap; }
+
     SectionPlane& addSectionPlane(const SectionPlane& plane);
     void clearSectionPlanes();
     void reset();
@@ -30,9 +126,77 @@ public:
     bool loadFromFile(const std::string& filename);
 
 private:
+    struct PrototypeNode {
+        NodeKind kind = NodeKind::Geometry;
+        std::string name;
+        GeometryObject* geometry = nullptr;
+        std::vector<TagId> tags;
+        std::vector<std::unique_ptr<PrototypeNode>> children;
+    };
+
+    struct ComponentDefinition {
+        ComponentDefinitionId id = 0;
+        std::string name;
+        GeometryKernel geometry;
+        std::vector<std::unique_ptr<PrototypeNode>> roots;
+    };
+
+    ObjectNode* addNode(NodeKind kind, const std::string& name, ObjectNode* parent);
+    void removeNode(ObjectNode* node);
+    void removeChildGeometry(ObjectNode& node);
+    void removeChildNode(ObjectNode& node, ObjectNode* child);
+    void forEachNode(const std::function<void(ObjectNode&)>& fn);
+    void forEachNode(const std::function<void(const ObjectNode&)>& fn) const;
+    void rebuildIndices();
+    void updateVisibility();
+    void applyVisibilityRecursive(ObjectNode& node, const std::unordered_set<TagId>& hiddenTags,
+                                  const std::unordered_set<ObjectId>& isolatedIds, bool ancestorVisible);
+    void collectIsolationIds(const ObjectNode& node, std::unordered_set<ObjectId>& ids) const;
+    ObjectNode* findMutable(ObjectId id);
+    const ObjectNode* findConst(ObjectId id) const;
+    bool isDescendantOf(const ObjectNode& node, const ObjectNode& ancestor) const;
+    std::unique_ptr<PrototypeNode> buildPrototypeFromNode(const ObjectNode& node, ComponentDefinition& definition);
+    std::unique_ptr<ObjectNode> instantiatePrototype(const PrototypeNode& proto, ComponentDefinition& definition, ObjectNode* parent);
+    void registerNode(ObjectNode* node);
+    void unregisterNode(ObjectNode* node);
+    void registerGeometry(ObjectNode* node, GeometryObject* geometry);
+    void unregisterGeometry(GeometryObject* geometry);
+    void detachFromParent(ObjectNode* node);
+    std::unique_ptr<ObjectNode> detachChild(ObjectNode* node);
+    void captureSceneState(const CameraController& camera, SceneState& state) const;
+    void applySceneState(const SceneState& state, CameraController& camera);
+    void serializeObjectTree(std::ostream& os) const;
+    void serializeNode(std::ostream& os, const ObjectNode& node,
+                       const std::unordered_map<const GeometryObject*, std::size_t>& geometryLookup) const;
+    bool deserializeObjectTree(std::istream& is, int version, const std::vector<GeometryObject*>& geometryObjects);
+    bool deserializeNode(std::istream& is, ObjectNode* parent, const std::vector<GeometryObject*>& geometryObjects, int version);
+    void serializeTags(std::ostream& os) const;
+    bool deserializeTags(std::istream& is);
+    void serializeComponentDefinitions(std::ostream& os) const;
+    bool deserializeComponentDefinitions(std::istream& is, int version);
+    void serializeScenes(std::ostream& os) const;
+    bool deserializeScenes(std::istream& is, int version);
+    bool parsePrototype(std::istream& is, const std::vector<GeometryObject*>& geometryObjects, PrototypeNode& proto);
+
     GeometryKernel geometryKernel;
     std::vector<SectionPlane> planes;
     SceneSettings sceneSettings;
+
+    std::unique_ptr<ObjectNode> rootNode;
+    ObjectId nextObjectId = 1;
+    TagId nextTagId = 1;
+    ComponentDefinitionId nextDefinitionId = 1;
+    SceneId nextSceneId = 1;
+
+    std::unordered_map<ObjectId, ObjectNode*> nodeIndex;
+    std::unordered_map<const GeometryObject*, ObjectId> geometryIndex;
+    std::unordered_map<TagId, Tag> tagMap;
+    std::unordered_map<ComponentDefinitionId, ComponentDefinition> componentDefinitions;
+    std::unordered_map<ComponentDefinitionId, std::vector<ObjectId>> componentInstances;
+    std::unordered_map<SceneId, SceneState> sceneMap;
+
+    bool colorByTagEnabled = false;
+    std::vector<ObjectId> isolationIds;
 };
 
 } // namespace Scene

--- a/tests/test_phase5.cpp
+++ b/tests/test_phase5.cpp
@@ -1,0 +1,205 @@
+#include <cassert>
+#include <filesystem>
+#include <vector>
+
+#include "CameraController.h"
+#include "Scene/Document.h"
+#include "GeometryKernel/Vector3.h"
+
+using Scene::Document;
+
+std::vector<Vector3> makeRectangle(float width, float depth)
+{
+    float hw = width * 0.5f;
+    float hd = depth * 0.5f;
+    return {
+        { -hw, 0.0f, -hd },
+        { hw, 0.0f, -hd },
+        { hw, 0.0f, hd },
+        { -hw, 0.0f, hd }
+    };
+}
+
+void testGroupingAndOutliner()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(2.0f, 1.0f));
+    GeometryObject* b = doc.geometry().addCurve(makeRectangle(1.5f, 1.5f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "A");
+    Document::ObjectId idB = doc.ensureObjectForGeometry(b, "B");
+
+    Document::ObjectId groupId = doc.createGroup({ idA, idB }, "Group");
+    assert(groupId != 0);
+    const auto* groupNode = doc.findObject(groupId);
+    assert(groupNode);
+    assert(groupNode->children.size() == 2);
+    for (const auto& child : groupNode->children) {
+        assert(child->parent == groupNode);
+    }
+
+    bool moved = doc.moveObject(idA, 0, 0);
+    assert(moved);
+    const auto& root = doc.objectTree();
+    bool foundA = false;
+    for (const auto& child : root.children) {
+        if (child->id == idA) {
+            foundA = true;
+            assert(child->parent == &root);
+        }
+    }
+    assert(foundA);
+}
+
+void testComponents()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(2.0f, 2.0f));
+    GeometryObject* b = doc.geometry().addCurve(makeRectangle(1.0f, 1.0f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "PanelA");
+    Document::ObjectId idB = doc.ensureObjectForGeometry(b, "PanelB");
+    Document::ObjectId groupId = doc.createGroup({ idA, idB }, "Panel");
+    assert(groupId != 0);
+
+    Document::ComponentDefinitionId defId = doc.createComponentDefinition({ groupId }, "PanelDef");
+    assert(defId != 0);
+    std::size_t before = doc.geometry().getObjects().size();
+    Document::ObjectId instId = doc.instantiateComponent(defId, "PanelInstance");
+    assert(instId != 0);
+    const auto* instanceNode = doc.findObject(instId);
+    assert(instanceNode);
+    assert(instanceNode->kind == Document::NodeKind::ComponentInstance);
+    assert(doc.geometry().getObjects().size() > before);
+    assert(!instanceNode->children.empty());
+    const GeometryObject* original = doc.findObject(idA)->geometry;
+    const GeometryObject* instGeom = instanceNode->children.front()->geometry;
+    assert(original != instGeom);
+
+    bool unique = doc.makeComponentUnique(instId);
+    assert(unique);
+    const auto* updatedInstance = doc.findObject(instId);
+    assert(updatedInstance->definitionId != defId);
+
+    doc.refreshComponentInstances(updatedInstance->definitionId);
+}
+
+void testTagsAndVisibility()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(1.0f, 1.0f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "Tagged");
+    Scene::SceneSettings::Color color{ 1.0f, 0.0f, 0.0f, 1.0f };
+    Document::TagId tagId = doc.createTag("Exterior", color);
+    bool assigned = doc.assignTag(idA, tagId);
+    assert(assigned);
+    bool hidden = doc.setTagVisible(tagId, false);
+    assert(hidden);
+    assert(a->isHidden());
+    doc.setTagVisible(tagId, true);
+    assert(!a->isHidden());
+    doc.setColorByTag(true);
+    assert(doc.colorByTag());
+}
+
+void testIsolation()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(1.0f, 1.0f));
+    GeometryObject* b = doc.geometry().addCurve(makeRectangle(1.0f, 2.0f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "IsoA");
+    Document::ObjectId idB = doc.ensureObjectForGeometry(b, "IsoB");
+    Document::ObjectId groupId = doc.createGroup({ idA }, "IsoGroup");
+    (void)groupId;
+    doc.isolate(idA);
+    assert(!a->isHidden());
+    assert(b->isHidden());
+    doc.clearIsolation();
+    assert(!a->isHidden());
+    assert(!b->isHidden());
+}
+
+void testScenes()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(1.0f, 1.0f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "SceneObj");
+    Scene::SceneSettings::Color color{ 0.2f, 0.3f, 0.4f, 1.0f };
+    Document::TagId tagId = doc.createTag("SceneTag", color);
+    doc.assignTag(idA, tagId);
+    doc.setTagVisible(tagId, false);
+    doc.setColorByTag(true);
+    doc.settings().setSectionPlanesVisible(false);
+    doc.settings().setSectionFillsVisible(false);
+
+    CameraController camera;
+    camera.setTarget(5.0f, 2.0f, -3.0f);
+    camera.setYawPitch(0.5f, 0.25f);
+    camera.setDistance(12.0f);
+    camera.setFieldOfView(50.0f);
+    camera.setProjectionMode(CameraController::ProjectionMode::Parallel);
+    camera.setOrthoHeight(6.0f);
+
+    Document::SceneId sceneId = doc.createScene("Primary", camera);
+    assert(sceneId != 0);
+
+    // mutate state
+    doc.setTagVisible(tagId, true);
+    doc.setColorByTag(false);
+    doc.settings().setSectionPlanesVisible(true);
+    doc.settings().setSectionFillsVisible(true);
+    camera.setTarget(0.0f, 0.0f, 0.0f);
+    camera.setYawPitch(1.0f, 0.8f);
+    camera.setDistance(20.0f);
+    camera.setProjectionMode(CameraController::ProjectionMode::Perspective);
+
+    bool applied = doc.applyScene(sceneId, camera);
+    assert(applied);
+    assert(doc.colorByTag());
+    assert(!doc.settings().sectionPlanesVisible());
+    assert(!doc.settings().sectionFillsVisible());
+    const auto& sceneTags = doc.tags();
+    auto it = sceneTags.find(tagId);
+    assert(it != sceneTags.end());
+    assert(!it->second.visible);
+    assert(camera.getProjectionMode() == CameraController::ProjectionMode::Parallel);
+}
+
+void testSerializationRoundTrip()
+{
+    Document doc;
+    GeometryObject* a = doc.geometry().addCurve(makeRectangle(1.0f, 1.0f));
+    Document::ObjectId idA = doc.ensureObjectForGeometry(a, "SaveA");
+    Document::TagId tagId = doc.createTag("Persist", { 0.1f, 0.2f, 0.3f, 1.0f });
+    doc.assignTag(idA, tagId);
+    doc.setTagVisible(tagId, false);
+
+    CameraController camera;
+    Document::SceneId sceneId = doc.createScene("Snapshot", camera);
+    assert(sceneId != 0);
+
+    std::filesystem::path path = std::filesystem::temp_directory_path() / "phase5_scene.fcm";
+    bool saved = doc.saveToFile(path.string());
+    assert(saved);
+
+    Document loaded;
+    bool loadedOk = loaded.loadFromFile(path.string());
+    std::filesystem::remove(path);
+    assert(loadedOk);
+    assert(loaded.tags().size() == doc.tags().size());
+    assert(!loaded.tags().empty());
+    assert(!loaded.tags().begin()->second.visible);
+    assert(loaded.scenes().size() == doc.scenes().size());
+    assert(!loaded.colorByTag());
+    assert(!loaded.objectTree().children.empty());
+}
+
+int main()
+{
+    testGroupingAndOutliner();
+    testComponents();
+    testTagsAndVisibility();
+    testIsolation();
+    testScenes();
+    testSerializationRoundTrip();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add full object management APIs to the scene document, including groups, components, tags, scenes, and serialization helpers
- enable cloning of geometry objects inside the kernel so component instances have independent geometry
- introduce a Phase 5 regression test and wire it into the CMake test suite

## Testing
- `./build_test_phase5`