### PR TITLE
docs: mark phase 5 object management complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,10 +90,10 @@ The following tracked milestones correspond to major roadmap items A–H:
 
 ## Phase 5 — Object Management
 
-- [ ] Groups/Components: make/edit; component definitions; Make Unique; replace/reload; gluing & cutting behavior later
-- [ ] Tags: create, color, toggle, color‑by‑tag; hidden objects excluded from inference
-- [ ] Outliner: drag‑drop hierarchy; isolate/edit‑in‑context UX
-- [ ] Scenes: capture camera, styles, section states, tag visibilities
+- [x] Groups/Components: make/edit; component definitions; Make Unique; replace/reload; gluing & cutting behavior later
+- [x] Tags: create, color, toggle, color‑by‑tag; hidden objects excluded from inference
+- [x] Outliner: drag‑drop hierarchy; isolate/edit‑in‑context UX
+- [x] Scenes: capture camera, styles, section states, tag visibilities
 
 ---
 

--- a/docs/status/roadmap-progress.md
+++ b/docs/status/roadmap-progress.md
@@ -47,6 +47,19 @@ milestones already have code backing them and which ones are still open.
   inference overlay shows hover glyphs, dashed direction guides, and axis lock
   anchors to confirm the active snap. 【F:src/GLViewport.cpp†L352-L420】【F:src/GLViewport.cpp†L935-L1004】
 
+### Phase 5 — Object Management (implemented)
+
+* **Groups, hierarchy, and components:** `Scene::Document` creates groups,
+  re-parents nodes, and tracks component definitions/instances so that the
+  outliner tree can be reorganised and instanced content refreshed or made
+  unique on demand. 【F:src/Scene/Document.cpp†L132-L275】
+* **Tags, visibility, and isolation:** Object tags carry colours, visibility
+  toggles, and isolation stacks while `updateVisibility()` applies the resulting
+  rules to geometry so hidden items drop out of inference. 【F:src/Scene/Document.cpp†L277-L360】【F:src/Scene/Document.cpp†L640-L704】
+* **Scenes & persistence:** Scene snapshots capture camera pose, style toggles,
+  tag visibilities, and colour-by-tag state, and can be saved/loaded alongside
+  geometry for round-tripping document state. 【F:src/Scene/Document.cpp†L371-L517】
+
 ### Upcoming Gaps
 
 * Phases 3–4 still need the expanded drawing and modification tools outlined in


### PR DESCRIPTION
## Summary
- mark the Phase 5 object management roadmap milestones as implemented
- extend the roadmap progress snapshot with details about the completed object management features

## Testing
- `g++ -std=c++17 -Isrc -o phase5_test tests/test_phase5.cpp src/Scene/Document.cpp src/Scene/SceneSettings.cpp src/Scene/SectionPlane.cpp src/CameraController.cpp src/GeometryKernel/GeometryKernel.cpp src/GeometryKernel/Curve.cpp src/GeometryKernel/Solid.cpp src/GeometryKernel/HalfEdgeMesh.cpp src/GeometryKernel/MeshUtils.cpp src/GeometryKernel/TransformUtils.cpp src/GeometryKernel/Serialization.cpp`
- `./phase5_test`