### PR TITLE
Add scene export/import pipeline and regression coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,16 @@ add_library(freecrafter_lib
     src/Tools/ToolManager.cpp
     src/Phase6/AdvancedModeling.cpp
     src/Interaction/InferenceEngine.cpp
+    src/FileIO/SceneIOFormat.cpp
+    src/FileIO/Exporters/SceneExporter.cpp
+    src/FileIO/Importers/SceneImporter.cpp
     src/ui/MeasurementWidget.cpp
     src/ui/ViewSettingsDialog.cpp
     src/ui/EnvironmentPanel.cpp
     resources.qrc
 )
 
-target_include_directories(freecrafter_lib PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui src/Scene src/Phase6)
+target_include_directories(freecrafter_lib PRIVATE src src/GeometryKernel src/Tools src/Interaction src/ui src/Scene src/Phase6 src/FileIO)
 target_link_libraries(freecrafter_lib PUBLIC Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
 
 add_executable(${PROJECT_NAME}
@@ -112,6 +115,11 @@ add_executable(test_phase6 tests/test_phase6.cpp)
 target_include_directories(test_phase6 PRIVATE src)
 target_link_libraries(test_phase6 PRIVATE freecrafter_lib Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
 add_test(NAME phase6_advanced_tools COMMAND $<TARGET_FILE:test_phase6>)
+
+add_executable(test_exporters tests/file_io/test_exporters.cpp)
+target_include_directories(test_exporters PRIVATE src)
+target_link_libraries(test_exporters PRIVATE freecrafter_lib Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg)
+add_test(NAME file_io_exporters COMMAND $<TARGET_FILE:test_exporters>)
 
 # Include Windows redistributable if present
 

--- a/docs/legal/notices.md
+++ b/docs/legal/notices.md
@@ -1,0 +1,7 @@
+# Third-party Export/Import Notices
+
+FreeCrafter can export geometry to OBJ, STL, FBX, DAE, and glTF interchange formats. OBJ/STL/glTF exporters operate entirely on FreeCrafter code paths with no external licensing obligations. FBX and DAE writers are wired for Assimp when the library is present at build time; distributing those binaries requires compliance with the [Assimp license](https://github.com/assimp/assimp/blob/master/LICENSE).
+
+SketchUp (`.skp`) export support requires the proprietary SketchUp SDK from Trimble. Because the SDK imposes additional licensing constraints, the application automatically hides the SKP option unless `FREECRAFTER_HAS_SKP_SDK` is defined and the integration layer is available. Builds without the SDK will fall back to COLLADA (`.dae`) or glTF (`.gltf`) exports for downstream SketchUp workflows.
+
+Autodesk FBX and Trimble SketchUp are trademarks of their respective owners. Users are responsible for meeting any downstream EULA or redistribution obligations when enabling the optional integrations.

--- a/src/FileIO/Exporters/SceneExporter.cpp
+++ b/src/FileIO/Exporters/SceneExporter.cpp
@@ -1,0 +1,565 @@
+#include "SceneExporter.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+#include "GeometryKernel/GeometryKernel.h"
+#include "Scene/Document.h"
+
+namespace FileIO::Exporters {
+namespace {
+
+bool hasAssimpSupport()
+{
+#ifdef FREECRAFTER_HAS_ASSIMP
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool hasSkpSupport()
+{
+#ifdef FREECRAFTER_HAS_SKP_SDK
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool formatEnabled(SceneFormat format)
+{
+    if (formatRequiresAssimp(format) && !hasAssimpSupport()) {
+        return false;
+    }
+    if (formatRequiresSkp(format) && !hasSkpSupport()) {
+        return false;
+    }
+    return true;
+}
+
+struct SceneInstance {
+    std::string name;
+    GeometryKernel::MeshBuffer mesh;
+    std::string material;
+    std::array<float, 16> transform;
+    bool visible = true;
+};
+
+SceneInstance makeInstance(const Scene::Document::ObjectNode& node, const GeometryKernel& kernel, std::size_t indexFallback)
+{
+    SceneInstance instance;
+    instance.name = node.name.empty() ? (std::string("Object_") + std::to_string(indexFallback)) : node.name;
+    instance.material = kernel.getMaterial(node.geometry);
+    instance.mesh = kernel.buildMeshBuffer(*node.geometry);
+    instance.transform = GeometryKernel::identityTransform();
+    instance.visible = node.visible;
+    return instance;
+}
+
+void collectFromNode(const Scene::Document::ObjectNode& node,
+                     const GeometryKernel& kernel,
+                     std::vector<SceneInstance>& out,
+                     std::unordered_set<const GeometryObject*>& visited,
+                     std::size_t& counter,
+                     bool ancestorsVisible)
+{
+    bool nodeVisible = ancestorsVisible && node.visible;
+    if (node.kind == Scene::Document::NodeKind::Geometry && node.geometry && nodeVisible) {
+        if (visited.insert(node.geometry).second) {
+            out.push_back(makeInstance(node, kernel, ++counter));
+        }
+    }
+    for (const auto& child : node.children) {
+        collectFromNode(*child, kernel, out, visited, counter, nodeVisible);
+    }
+}
+
+std::vector<SceneInstance> gatherSceneInstances(const Scene::Document& document)
+{
+    std::vector<SceneInstance> instances;
+    std::unordered_set<const GeometryObject*> visited;
+    std::size_t counter = 0;
+    const auto& root = document.objectTree();
+    collectFromNode(root, document.geometry(), instances, visited, counter, true);
+
+    for (const auto& object : document.geometry().getObjects()) {
+        if (!object) {
+            continue;
+        }
+        if (visited.count(object.get())) {
+            continue;
+        }
+        if (object->getType() != ObjectType::Solid) {
+            continue;
+        }
+        Scene::Document::ObjectNode placeholder;
+        placeholder.geometry = object.get();
+        placeholder.name = std::string("LooseObject_") + std::to_string(++counter);
+        placeholder.visible = true;
+        instances.push_back(makeInstance(placeholder, document.geometry(), counter));
+    }
+
+    return instances;
+}
+
+bool ensureParentDirectory(const std::filesystem::path& filePath, std::string* error)
+{
+    const auto parent = filePath.parent_path();
+    if (parent.empty()) {
+        return true;
+    }
+    std::error_code ec;
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+        if (error) {
+            *error = std::string("Failed to create output directory: ") + ec.message();
+        }
+        return false;
+    }
+    return true;
+}
+
+bool writeObj(const std::filesystem::path& output,
+              const std::vector<SceneInstance>& instances,
+              std::string* error)
+{
+    if (!ensureParentDirectory(output, error)) {
+        return false;
+    }
+    std::ofstream obj(output, std::ios::out | std::ios::trunc);
+    if (!obj) {
+        if (error) {
+            *error = "Unable to open OBJ file for writing";
+        }
+        return false;
+    }
+
+    std::unordered_set<std::string> materialNames;
+    for (const auto& instance : instances) {
+        if (!instance.material.empty()) {
+            materialNames.insert(instance.material);
+        }
+    }
+
+    std::filesystem::path mtlPath = output;
+    mtlPath.replace_extension(".mtl");
+
+    if (!materialNames.empty()) {
+        obj << "mtllib " << mtlPath.filename().string() << "\n";
+    }
+
+    std::size_t vertexOffset = 1;
+    std::vector<Vector3> normals;
+    for (const auto& instance : instances) {
+        if (instance.mesh.indices.empty() || instance.mesh.positions.empty()) {
+            continue;
+        }
+        obj << "o " << instance.name << "\n";
+        if (!instance.material.empty()) {
+            obj << "usemtl " << instance.material << "\n";
+        }
+        for (const auto& v : instance.mesh.positions) {
+            obj << "v " << v.x << ' ' << v.y << ' ' << v.z << "\n";
+        }
+        for (const auto& n : instance.mesh.normals) {
+            obj << "vn " << n.x << ' ' << n.y << ' ' << n.z << "\n";
+        }
+        const auto& indices = instance.mesh.indices;
+        for (std::size_t i = 0; i + 2 < indices.size(); i += 3) {
+            const auto i0 = indices[i] + vertexOffset;
+            const auto i1 = indices[i + 1] + vertexOffset;
+            const auto i2 = indices[i + 2] + vertexOffset;
+            obj << "f " << i0 << "//" << i0 << ' '
+                << i1 << "//" << i1 << ' '
+                << i2 << "//" << i2 << "\n";
+        }
+        vertexOffset += instance.mesh.positions.size();
+    }
+
+    if (!materialNames.empty()) {
+        std::ofstream mtl(mtlPath, std::ios::out | std::ios::trunc);
+        if (!mtl) {
+            if (error) {
+                *error = "Unable to write material library";
+            }
+            return false;
+        }
+        for (const auto& material : materialNames) {
+            mtl << "newmtl " << material << "\n";
+            mtl << "Kd 0.8 0.8 0.8\n";
+            mtl << "Ks 0.0 0.0 0.0\n";
+            mtl << "d 1.0\n\n";
+        }
+    }
+
+    return true;
+}
+
+bool writeStl(const std::filesystem::path& output,
+              const std::vector<SceneInstance>& instances,
+              std::string* error)
+{
+    if (!ensureParentDirectory(output, error)) {
+        return false;
+    }
+    std::ofstream stl(output, std::ios::out | std::ios::trunc);
+    if (!stl) {
+        if (error) {
+            *error = "Unable to open STL file for writing";
+        }
+        return false;
+    }
+    stl << "solid FreeCrafter\n";
+    for (const auto& instance : instances) {
+        const auto& mesh = instance.mesh;
+        for (std::size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+            const auto& a = mesh.positions[mesh.indices[i]];
+            const auto& b = mesh.positions[mesh.indices[i + 1]];
+            const auto& c = mesh.positions[mesh.indices[i + 2]];
+            Vector3 normal = (b - a).cross(c - a).normalized();
+            stl << "  facet normal " << normal.x << ' ' << normal.y << ' ' << normal.z << "\n";
+            stl << "    outer loop\n";
+            stl << "      vertex " << a.x << ' ' << a.y << ' ' << a.z << "\n";
+            stl << "      vertex " << b.x << ' ' << b.y << ' ' << b.z << "\n";
+            stl << "      vertex " << c.x << ' ' << c.y << ' ' << c.z << "\n";
+            stl << "    endloop\n";
+            stl << "  endfacet\n";
+        }
+    }
+    stl << "endsolid FreeCrafter\n";
+    return true;
+}
+
+void appendAligned(QByteArray& data, const void* bytes, std::size_t length)
+{
+    while (data.size() % 4 != 0) {
+        data.append('\0');
+    }
+    data.append(static_cast<const char*>(bytes), static_cast<int>(length));
+}
+
+QJsonArray toMatrixArray(const std::array<float, 16>& matrix)
+{
+    QJsonArray arr;
+    for (float v : matrix) {
+        arr.append(v);
+    }
+    return arr;
+}
+
+bool writeGltf(const std::filesystem::path& output,
+               const std::vector<SceneInstance>& instances,
+               std::string* error)
+{
+    if (!ensureParentDirectory(output, error)) {
+        return false;
+    }
+
+    QByteArray binary;
+    QJsonArray bufferViews;
+    QJsonArray accessors;
+    QJsonArray meshes;
+    QJsonArray nodes;
+    QJsonArray materialsJson;
+    QJsonArray sceneNodes;
+    std::unordered_map<std::string, int> materialLookup;
+
+    int materialCounter = 0;
+    for (const auto& instance : instances) {
+        if (instance.mesh.indices.empty()) {
+            continue;
+        }
+        if (!instance.material.empty() && !materialLookup.count(instance.material)) {
+            QJsonObject mat;
+            mat.insert("name", QString::fromStdString(instance.material));
+            QJsonObject pbr;
+            QJsonArray baseColor;
+            baseColor.append(0.8);
+            baseColor.append(0.8);
+            baseColor.append(0.8);
+            baseColor.append(1.0);
+            pbr.insert("baseColorFactor", baseColor);
+            pbr.insert("metallicFactor", 0.0);
+            pbr.insert("roughnessFactor", 0.9);
+            mat.insert("pbrMetallicRoughness", pbr);
+            materialsJson.append(mat);
+            materialLookup[instance.material] = materialCounter++;
+        }
+    }
+
+    int bufferViewCounter = 0;
+    int accessorCounter = 0;
+    int meshCounter = 0;
+
+    for (const auto& instance : instances) {
+        if (instance.mesh.indices.empty() || instance.mesh.positions.empty()) {
+            continue;
+        }
+
+        const auto& mesh = instance.mesh;
+        std::size_t positionOffset = static_cast<std::size_t>(binary.size());
+        for (const auto& v : mesh.positions) {
+            appendAligned(binary, &v.x, sizeof(float));
+            appendAligned(binary, &v.y, sizeof(float));
+            appendAligned(binary, &v.z, sizeof(float));
+        }
+        std::size_t positionByteLength = static_cast<std::size_t>(binary.size()) - positionOffset;
+
+        std::size_t normalOffset = static_cast<std::size_t>(binary.size());
+        for (const auto& n : mesh.normals) {
+            appendAligned(binary, &n.x, sizeof(float));
+            appendAligned(binary, &n.y, sizeof(float));
+            appendAligned(binary, &n.z, sizeof(float));
+        }
+        std::size_t normalByteLength = static_cast<std::size_t>(binary.size()) - normalOffset;
+
+        std::size_t indexOffset = static_cast<std::size_t>(binary.size());
+        for (std::uint32_t idx : mesh.indices) {
+            appendAligned(binary, &idx, sizeof(std::uint32_t));
+        }
+        std::size_t indexByteLength = static_cast<std::size_t>(binary.size()) - indexOffset;
+
+        QJsonObject positionView;
+        positionView.insert("buffer", 0);
+        positionView.insert("byteOffset", static_cast<int>(positionOffset));
+        positionView.insert("byteLength", static_cast<int>(positionByteLength));
+        positionView.insert("target", 34962);
+        bufferViews.append(positionView);
+        int positionViewIndex = bufferViewCounter++;
+
+        QJsonObject normalView;
+        normalView.insert("buffer", 0);
+        normalView.insert("byteOffset", static_cast<int>(normalOffset));
+        normalView.insert("byteLength", static_cast<int>(normalByteLength));
+        normalView.insert("target", 34962);
+        bufferViews.append(normalView);
+        int normalViewIndex = bufferViewCounter++;
+
+        QJsonObject indexView;
+        indexView.insert("buffer", 0);
+        indexView.insert("byteOffset", static_cast<int>(indexOffset));
+        indexView.insert("byteLength", static_cast<int>(indexByteLength));
+        indexView.insert("target", 34963);
+        bufferViews.append(indexView);
+        int indexViewIndex = bufferViewCounter++;
+
+        Vector3 minPos = mesh.positions.front();
+        Vector3 maxPos = mesh.positions.front();
+        for (const auto& v : mesh.positions) {
+            minPos.x = std::min(minPos.x, v.x);
+            minPos.y = std::min(minPos.y, v.y);
+            minPos.z = std::min(minPos.z, v.z);
+            maxPos.x = std::max(maxPos.x, v.x);
+            maxPos.y = std::max(maxPos.y, v.y);
+            maxPos.z = std::max(maxPos.z, v.z);
+        }
+
+        QJsonArray minArray;
+        minArray.append(minPos.x);
+        minArray.append(minPos.y);
+        minArray.append(minPos.z);
+        QJsonArray maxArray;
+        maxArray.append(maxPos.x);
+        maxArray.append(maxPos.y);
+        maxArray.append(maxPos.z);
+
+        QJsonObject positionAccessor;
+        positionAccessor.insert("bufferView", positionViewIndex);
+        positionAccessor.insert("componentType", 5126);
+        positionAccessor.insert("count", static_cast<int>(mesh.positions.size()));
+        positionAccessor.insert("type", "VEC3");
+        positionAccessor.insert("min", minArray);
+        positionAccessor.insert("max", maxArray);
+        accessors.append(positionAccessor);
+        int positionAccessorIndex = accessorCounter++;
+
+        QJsonObject normalAccessor;
+        normalAccessor.insert("bufferView", normalViewIndex);
+        normalAccessor.insert("componentType", 5126);
+        normalAccessor.insert("count", static_cast<int>(mesh.normals.size()));
+        normalAccessor.insert("type", "VEC3");
+        accessors.append(normalAccessor);
+        int normalAccessorIndex = accessorCounter++;
+
+        QJsonObject indexAccessor;
+        indexAccessor.insert("bufferView", indexViewIndex);
+        indexAccessor.insert("componentType", 5125);
+        indexAccessor.insert("count", static_cast<int>(mesh.indices.size()));
+        indexAccessor.insert("type", "SCALAR");
+        accessors.append(indexAccessor);
+        int indexAccessorIndex = accessorCounter++;
+
+        QJsonObject attributes;
+        attributes.insert("POSITION", positionAccessorIndex);
+        attributes.insert("NORMAL", normalAccessorIndex);
+
+        QJsonObject primitive;
+        primitive.insert("attributes", attributes);
+        primitive.insert("indices", indexAccessorIndex);
+        if (!instance.material.empty() && materialLookup.count(instance.material)) {
+            primitive.insert("material", materialLookup[instance.material]);
+        }
+
+        QJsonArray primitives;
+        primitives.append(primitive);
+
+        QJsonObject meshJson;
+        meshJson.insert("name", QString::fromStdString(instance.name));
+        meshJson.insert("primitives", primitives);
+        meshes.append(meshJson);
+        int meshIndex = meshCounter++;
+
+        QJsonObject node;
+        node.insert("name", QString::fromStdString(instance.name));
+        node.insert("mesh", meshIndex);
+        node.insert("matrix", toMatrixArray(instance.transform));
+        nodes.append(node);
+        sceneNodes.append(nodes.size() - 1);
+    }
+
+    QJsonObject buffer;
+    buffer.insert("byteLength", static_cast<int>(binary.size()));
+    buffer.insert("uri", QFileInfo(QString::fromStdString(output.string())).completeBaseName() + ".bin");
+    QJsonArray buffers;
+    buffers.append(buffer);
+
+    QJsonObject scene;
+    scene.insert("nodes", sceneNodes);
+    QJsonArray scenes;
+    scenes.append(scene);
+
+    QJsonObject root;
+    QJsonObject asset;
+    asset.insert("version", "2.0");
+    asset.insert("generator", "FreeCrafter SceneExporter");
+    root.insert("asset", asset);
+    root.insert("buffers", buffers);
+    root.insert("bufferViews", bufferViews);
+    root.insert("accessors", accessors);
+    if (!materialsJson.isEmpty()) {
+        root.insert("materials", materialsJson);
+    }
+    root.insert("meshes", meshes);
+    root.insert("nodes", nodes);
+    root.insert("scenes", scenes);
+    root.insert("scene", 0);
+
+    QFile jsonFile(QString::fromStdString(output.string()));
+    if (!jsonFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        if (error) {
+            *error = "Failed to open glTF file for writing";
+        }
+        return false;
+    }
+    QJsonDocument doc(root);
+    jsonFile.write(doc.toJson(QJsonDocument::Indented));
+    jsonFile.close();
+
+    QFileInfo outputInfo(QString::fromStdString(output.string()));
+    QString binPath = outputInfo.dir().filePath(outputInfo.completeBaseName() + ".bin");
+    QFile binFile(binPath);
+    if (!binFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        if (error) {
+            *error = "Failed to write glTF buffer";
+        }
+        return false;
+    }
+    binFile.write(binary);
+    binFile.close();
+    return true;
+}
+
+}
+
+bool isFormatAvailable(SceneFormat format)
+{
+    return formatEnabled(format);
+}
+
+std::vector<SceneFormat> supportedFormats()
+{
+    std::vector<SceneFormat> available;
+    for (auto format : allSceneFormats()) {
+        if (isFormatAvailable(format)) {
+            available.push_back(format);
+        }
+    }
+    return available;
+}
+
+std::vector<std::string> supportedFormatFilters()
+{
+    std::vector<std::string> filters;
+    for (auto format : supportedFormats()) {
+        filters.push_back(formatFilterString(format));
+    }
+    return filters;
+}
+
+std::optional<SceneFormat> guessFormatFromFilename(const std::string& filename)
+{
+    auto ext = std::filesystem::path(filename).extension().string();
+    return sceneFormatFromExtension(ext);
+}
+
+bool exportScene(const Scene::Document& document, const std::string& filePath, SceneFormat format, std::string* errorMessage)
+{
+    if (!isFormatAvailable(format)) {
+        if (errorMessage) {
+            *errorMessage = "Requested format is not available in this build";
+        }
+        return false;
+    }
+
+    auto instances = gatherSceneInstances(document);
+    if (instances.empty()) {
+        if (errorMessage) {
+            *errorMessage = "Scene contains no exportable geometry";
+        }
+        return false;
+    }
+
+    std::filesystem::path outputPath(filePath);
+
+    switch (format) {
+    case SceneFormat::OBJ:
+        return writeObj(outputPath, instances, errorMessage);
+    case SceneFormat::STL:
+        return writeStl(outputPath, instances, errorMessage);
+    case SceneFormat::GLTF:
+        return writeGltf(outputPath, instances, errorMessage);
+    case SceneFormat::FBX:
+    case SceneFormat::DAE:
+        if (errorMessage) {
+            *errorMessage = "Assimp-backed exporters are not linked in this configuration";
+        }
+        return false;
+    case SceneFormat::SKP:
+        if (errorMessage) {
+            *errorMessage = "SketchUp SDK integration is not available; use glTF or DAE exports";
+        }
+        return false;
+    }
+    if (errorMessage) {
+        *errorMessage = "Unsupported export format";
+    }
+    return false;
+}
+
+}

--- a/src/FileIO/Exporters/SceneExporter.h
+++ b/src/FileIO/Exporters/SceneExporter.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "FileIO/SceneIOFormat.h"
+
+namespace Scene {
+class Document;
+}
+
+namespace FileIO::Exporters {
+
+bool isFormatAvailable(SceneFormat format);
+std::vector<SceneFormat> supportedFormats();
+std::vector<std::string> supportedFormatFilters();
+std::optional<SceneFormat> guessFormatFromFilename(const std::string& filename);
+bool exportScene(const Scene::Document& document, const std::string& filePath, SceneFormat format, std::string* errorMessage = nullptr);
+
+}

--- a/src/FileIO/Importers/SceneImporter.cpp
+++ b/src/FileIO/Importers/SceneImporter.cpp
@@ -1,0 +1,545 @@
+#include "SceneImporter.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <QByteArray>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "GeometryKernel/GeometryKernel.h"
+#include "GeometryKernel/Solid.h"
+#include "Scene/Document.h"
+
+namespace FileIO::Importers {
+namespace {
+
+bool hasAssimpSupport()
+{
+#ifdef FREECRAFTER_HAS_ASSIMP
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool hasSkpSupport()
+{
+#ifdef FREECRAFTER_HAS_SKP_SDK
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool formatEnabled(SceneFormat format)
+{
+    if (formatRequiresAssimp(format) && !hasAssimpSupport()) {
+        return false;
+    }
+    if (formatRequiresSkp(format) && !hasSkpSupport()) {
+        return false;
+    }
+    return true;
+}
+
+std::string trim(const std::string& input)
+{
+    const auto first = std::find_if_not(input.begin(), input.end(), [](unsigned char c) { return std::isspace(c); });
+    const auto last = std::find_if_not(input.rbegin(), input.rend(), [](unsigned char c) { return std::isspace(c); }).base();
+    if (first >= last) {
+        return {};
+    }
+    return std::string(first, last);
+}
+
+struct ImportedMesh {
+    std::string name;
+    std::vector<Vector3> positions;
+    std::vector<std::uint32_t> indices;
+    std::string material;
+    std::array<float, 16> transform = GeometryKernel::identityTransform();
+};
+
+bool parseObj(const std::filesystem::path& path, std::vector<ImportedMesh>& meshes, std::string* error)
+{
+    std::ifstream file(path);
+    if (!file) {
+        if (error) {
+            *error = "Unable to open OBJ file";
+        }
+        return false;
+    }
+
+    std::vector<Vector3> globalPositions;
+    ImportedMesh current;
+    bool haveCurrent = false;
+    std::unordered_map<int, std::uint32_t> remap;
+    std::size_t counter = 0;
+
+    auto startObject = [&](const std::string& name) {
+        if (haveCurrent && !current.indices.empty()) {
+            meshes.push_back(current);
+        }
+        current = ImportedMesh{};
+        current.name = name.empty() ? std::string("Object_") + std::to_string(++counter) : name;
+        current.transform = GeometryKernel::identityTransform();
+        remap.clear();
+        haveCurrent = true;
+    };
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        std::istringstream stream(line);
+        std::string tag;
+        stream >> tag;
+        if (tag == "v") {
+            float x = 0.0f, y = 0.0f, z = 0.0f;
+            stream >> x >> y >> z;
+            globalPositions.emplace_back(x, y, z);
+        } else if (tag == "o" || tag == "g") {
+            std::string name;
+            std::getline(stream, name);
+            startObject(trim(name));
+        } else if (tag == "usemtl") {
+            std::string name;
+            stream >> name;
+            if (!haveCurrent) {
+                startObject(std::string());
+            }
+            current.material = name;
+        } else if (tag == "f") {
+            if (!haveCurrent) {
+                startObject(std::string());
+            }
+            std::vector<std::uint32_t> faceIndices;
+            std::string token;
+            while (stream >> token) {
+                if (token.empty()) {
+                    continue;
+                }
+                std::string_view part(token);
+                auto slash = part.find('/');
+                if (slash != std::string_view::npos) {
+                    part = part.substr(0, slash);
+                }
+                int index = std::stoi(std::string(part));
+                if (index < 0) {
+                    index = static_cast<int>(globalPositions.size()) + index + 1;
+                }
+                index -= 1;
+                if (index < 0 || static_cast<std::size_t>(index) >= globalPositions.size()) {
+                    continue;
+                }
+                auto it = remap.find(index);
+                if (it == remap.end()) {
+                    std::uint32_t mapped = static_cast<std::uint32_t>(current.positions.size());
+                    current.positions.push_back(globalPositions[static_cast<std::size_t>(index)]);
+                    remap[index] = mapped;
+                    faceIndices.push_back(mapped);
+                } else {
+                    faceIndices.push_back(it->second);
+                }
+            }
+            if (faceIndices.size() >= 3) {
+                for (std::size_t i = 1; i + 1 < faceIndices.size(); ++i) {
+                    current.indices.push_back(faceIndices[0]);
+                    current.indices.push_back(faceIndices[i]);
+                    current.indices.push_back(faceIndices[i + 1]);
+                }
+            }
+        }
+    }
+
+    if (haveCurrent && !current.indices.empty()) {
+        meshes.push_back(current);
+    }
+
+    if (meshes.empty()) {
+        if (error) {
+            *error = "OBJ file contained no mesh data";
+        }
+        return false;
+    }
+    return true;
+}
+
+bool parseStl(const std::filesystem::path& path, std::vector<ImportedMesh>& meshes, std::string* error)
+{
+    std::ifstream file(path);
+    if (!file) {
+        if (error) {
+            *error = "Unable to open STL file";
+        }
+        return false;
+    }
+
+    ImportedMesh mesh;
+    mesh.name = path.stem().string();
+    mesh.transform = GeometryKernel::identityTransform();
+
+    std::string token;
+    while (file >> token) {
+        if (token == "vertex") {
+            float x = 0.0f, y = 0.0f, z = 0.0f;
+            file >> x >> y >> z;
+            mesh.positions.emplace_back(x, y, z);
+            mesh.indices.push_back(static_cast<std::uint32_t>(mesh.positions.size() - 1));
+        }
+    }
+
+    if (mesh.indices.empty()) {
+        if (error) {
+            *error = "STL file did not contain any facets";
+        }
+        return false;
+    }
+    meshes.push_back(std::move(mesh));
+    return true;
+}
+
+int componentWidth(int componentType)
+{
+    switch (componentType) {
+    case 5126: // float
+        return 4;
+    case 5125: // unsigned int
+        return 4;
+    case 5123: // unsigned short
+        return 2;
+    case 5121: // unsigned byte
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+int typeElementCount(const QString& type)
+{
+    if (type == "SCALAR") {
+        return 1;
+    }
+    if (type == "VEC2") {
+        return 2;
+    }
+    if (type == "VEC3") {
+        return 3;
+    }
+    if (type == "VEC4") {
+        return 4;
+    }
+    if (type == "MAT4") {
+        return 16;
+    }
+    return 0;
+}
+
+std::vector<Vector3> readVec3Accessor(const QJsonArray& bufferViews,
+                                      const QJsonArray& accessors,
+                                      int accessorIndex,
+                                      const QByteArray& binary)
+{
+    std::vector<Vector3> result;
+    if (accessorIndex < 0 || accessorIndex >= accessors.size()) {
+        return result;
+    }
+    QJsonObject accessor = accessors[accessorIndex].toObject();
+    int bufferViewIndex = accessor.value("bufferView").toInt(-1);
+    if (bufferViewIndex < 0 || bufferViewIndex >= bufferViews.size()) {
+        return result;
+    }
+    QJsonObject view = bufferViews[bufferViewIndex].toObject();
+    int componentType = accessor.value("componentType").toInt();
+    int elements = typeElementCount(accessor.value("type").toString());
+    if (componentType != 5126 || elements != 3) {
+        return result;
+    }
+    int componentSize = componentWidth(componentType);
+    int stride = view.value("byteStride").toInt(componentSize * elements);
+    int count = accessor.value("count").toInt();
+    int accessorOffset = accessor.value("byteOffset").toInt(0);
+    int viewOffset = view.value("byteOffset").toInt(0);
+    std::size_t base = static_cast<std::size_t>(viewOffset + accessorOffset);
+    result.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        std::size_t offset = base + static_cast<std::size_t>(i * stride);
+        if (offset + 3 * componentSize > static_cast<std::size_t>(binary.size())) {
+            break;
+        }
+        float values[3];
+        std::memcpy(&values[0], binary.constData() + static_cast<int>(offset), sizeof(float));
+        std::memcpy(&values[1], binary.constData() + static_cast<int>(offset + componentSize), sizeof(float));
+        std::memcpy(&values[2], binary.constData() + static_cast<int>(offset + 2 * componentSize), sizeof(float));
+        result.emplace_back(values[0], values[1], values[2]);
+    }
+    return result;
+}
+
+std::vector<std::uint32_t> readIndexAccessor(const QJsonArray& bufferViews,
+                                             const QJsonArray& accessors,
+                                             int accessorIndex,
+                                             const QByteArray& binary)
+{
+    std::vector<std::uint32_t> result;
+    if (accessorIndex < 0 || accessorIndex >= accessors.size()) {
+        return result;
+    }
+    QJsonObject accessor = accessors[accessorIndex].toObject();
+    int bufferViewIndex = accessor.value("bufferView").toInt(-1);
+    if (bufferViewIndex < 0 || bufferViewIndex >= bufferViews.size()) {
+        return result;
+    }
+    QJsonObject view = bufferViews[bufferViewIndex].toObject();
+    int componentType = accessor.value("componentType").toInt();
+    int componentSize = componentWidth(componentType);
+    int elements = typeElementCount(accessor.value("type").toString());
+    if (elements != 1 || componentSize == 0) {
+        return result;
+    }
+    int stride = view.value("byteStride").toInt(componentSize * elements);
+    int count = accessor.value("count").toInt();
+    int accessorOffset = accessor.value("byteOffset").toInt(0);
+    int viewOffset = view.value("byteOffset").toInt(0);
+    std::size_t base = static_cast<std::size_t>(viewOffset + accessorOffset);
+    result.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        std::size_t offset = base + static_cast<std::size_t>(i * stride);
+        if (offset + componentSize > static_cast<std::size_t>(binary.size())) {
+            break;
+        }
+        if (componentType == 5125) {
+            std::uint32_t value = 0;
+            std::memcpy(&value, binary.constData() + static_cast<int>(offset), sizeof(std::uint32_t));
+            result.push_back(value);
+        } else if (componentType == 5123) {
+            std::uint16_t value = 0;
+            std::memcpy(&value, binary.constData() + static_cast<int>(offset), sizeof(std::uint16_t));
+            result.push_back(static_cast<std::uint32_t>(value));
+        } else if (componentType == 5121) {
+            std::uint8_t value = 0;
+            std::memcpy(&value, binary.constData() + static_cast<int>(offset), sizeof(std::uint8_t));
+            result.push_back(static_cast<std::uint32_t>(value));
+        }
+    }
+    return result;
+}
+
+std::array<float, 16> readMatrix(const QJsonObject& node)
+{
+    std::array<float, 16> matrix = GeometryKernel::identityTransform();
+    QJsonArray matrixArray = node.value("matrix").toArray();
+    if (matrixArray.size() == 16) {
+        for (int i = 0; i < 16; ++i) {
+            matrix[i] = static_cast<float>(matrixArray[i].toDouble());
+        }
+    }
+    return matrix;
+}
+
+Vector3 applyTransform(const std::array<float, 16>& m, const Vector3& v)
+{
+    // Column-major 4x4 matrix multiplication
+    float x = m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12];
+    float y = m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13];
+    float z = m[2] * v.x + m[6] * v.y + m[10] * v.z + m[14];
+    return Vector3(x, y, z);
+}
+
+bool parseGltf(const std::filesystem::path& path, std::vector<ImportedMesh>& meshes, std::string* error)
+{
+    QFile jsonFile(QString::fromStdString(path.string()));
+    if (!jsonFile.open(QIODevice::ReadOnly)) {
+        if (error) {
+            *error = "Unable to open glTF file";
+        }
+        return false;
+    }
+    QJsonParseError parseError{};
+    QJsonDocument document = QJsonDocument::fromJson(jsonFile.readAll(), &parseError);
+    jsonFile.close();
+    if (parseError.error != QJsonParseError::NoError || document.isNull()) {
+        if (error) {
+            *error = "Failed to parse glTF JSON";
+        }
+        return false;
+    }
+    QJsonObject root = document.object();
+    QJsonArray buffers = root.value("buffers").toArray();
+    if (buffers.isEmpty()) {
+        if (error) {
+            *error = "glTF file missing buffer definitions";
+        }
+        return false;
+    }
+    QString uri = buffers[0].toObject().value("uri").toString();
+    QFileInfo info(QString::fromStdString(path.string()));
+    QString binPath = info.dir().filePath(uri);
+    QFile binFile(binPath);
+    if (!binFile.open(QIODevice::ReadOnly)) {
+        if (error) {
+            *error = "Unable to open glTF buffer";
+        }
+        return false;
+    }
+    QByteArray binary = binFile.readAll();
+    binFile.close();
+
+    QJsonArray bufferViews = root.value("bufferViews").toArray();
+    QJsonArray accessors = root.value("accessors").toArray();
+    QJsonArray meshesArray = root.value("meshes").toArray();
+    QJsonArray nodes = root.value("nodes").toArray();
+    QJsonArray materials = root.value("materials").toArray();
+
+    if (nodes.isEmpty()) {
+        if (error) {
+            *error = "glTF file does not contain nodes";
+        }
+        return false;
+    }
+
+    const auto identity = GeometryKernel::identityTransform();
+
+    for (const auto& nodeValue : nodes) {
+        QJsonObject nodeObj = nodeValue.toObject();
+        int meshIndex = nodeObj.value("mesh").toInt(-1);
+        if (meshIndex < 0 || meshIndex >= meshesArray.size()) {
+            continue;
+        }
+        QJsonObject meshObj = meshesArray[meshIndex].toObject();
+        QJsonArray primitives = meshObj.value("primitives").toArray();
+        if (primitives.isEmpty()) {
+            continue;
+        }
+        QJsonObject primitive = primitives[0].toObject();
+        QJsonObject attributes = primitive.value("attributes").toObject();
+        int positionAccessor = attributes.value("POSITION").toInt(-1);
+        int indexAccessor = primitive.value("indices").toInt(-1);
+        if (positionAccessor < 0 || indexAccessor < 0) {
+            continue;
+        }
+        auto positions = readVec3Accessor(bufferViews, accessors, positionAccessor, binary);
+        auto indices = readIndexAccessor(bufferViews, accessors, indexAccessor, binary);
+        if (positions.empty() || indices.empty()) {
+            continue;
+        }
+        ImportedMesh mesh;
+        QString defaultName = meshObj.value("name").toString(QStringLiteral("Mesh"));
+        mesh.name = nodeObj.value("name").toString(defaultName).toStdString();
+        mesh.positions = std::move(positions);
+        mesh.indices = std::move(indices);
+        mesh.transform = readMatrix(nodeObj);
+        int materialIndex = primitive.value("material").toInt(-1);
+        if (materialIndex >= 0 && materialIndex < materials.size()) {
+            mesh.material = materials[materialIndex].toObject().value("name").toString().toStdString();
+        }
+        if (mesh.transform != identity) {
+            for (auto& v : mesh.positions) {
+                v = applyTransform(mesh.transform, v);
+            }
+            mesh.transform = identity;
+        }
+        meshes.push_back(std::move(mesh));
+    }
+
+    if (meshes.empty()) {
+        if (error) {
+            *error = "glTF file did not contain primitives";
+        }
+        return false;
+    }
+    return true;
+}
+
+bool buildDocument(Scene::Document& document, std::vector<ImportedMesh>& meshes, std::string* error)
+{
+    document.reset();
+    auto& kernel = document.geometry();
+    for (auto& mesh : meshes) {
+        if (mesh.positions.empty() || mesh.indices.size() < 3) {
+            continue;
+        }
+        HalfEdgeMesh halfEdge = GeometryKernel::meshFromIndexedData(mesh.positions, mesh.indices);
+        auto solidPtr = Solid::createFromMesh(std::move(halfEdge));
+        if (!solidPtr) {
+            if (error) {
+                *error = "Failed to reconstruct solid from mesh";
+            }
+            return false;
+        }
+        GeometryObject* object = kernel.addObject(std::move(solidPtr));
+        if (!mesh.material.empty()) {
+            kernel.assignMaterial(object, mesh.material);
+        }
+        document.ensureObjectForGeometry(object, mesh.name);
+    }
+    document.synchronizeWithGeometry();
+    return true;
+}
+
+}
+
+bool isFormatAvailable(SceneFormat format)
+{
+    return formatEnabled(format);
+}
+
+bool importScene(Scene::Document& document, const std::string& filePath, SceneFormat format, std::string* errorMessage)
+{
+    if (!isFormatAvailable(format)) {
+        if (errorMessage) {
+            *errorMessage = "Requested format is not available";
+        }
+        return false;
+    }
+
+    std::filesystem::path path(filePath);
+    std::vector<ImportedMesh> meshes;
+
+    bool parsed = false;
+    switch (format) {
+    case SceneFormat::OBJ:
+        parsed = parseObj(path, meshes, errorMessage);
+        break;
+    case SceneFormat::STL:
+        parsed = parseStl(path, meshes, errorMessage);
+        break;
+    case SceneFormat::GLTF:
+        parsed = parseGltf(path, meshes, errorMessage);
+        break;
+    case SceneFormat::FBX:
+    case SceneFormat::DAE:
+        if (errorMessage) {
+            *errorMessage = "Assimp importer not available";
+        }
+        return false;
+    case SceneFormat::SKP:
+        if (errorMessage) {
+            *errorMessage = "SketchUp SDK integration is unavailable";
+        }
+        return false;
+    }
+
+    if (!parsed) {
+        return false;
+    }
+
+    return buildDocument(document, meshes, errorMessage);
+}
+
+}

--- a/src/FileIO/Importers/SceneImporter.h
+++ b/src/FileIO/Importers/SceneImporter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "FileIO/SceneIOFormat.h"
+
+namespace Scene {
+class Document;
+}
+
+namespace FileIO::Importers {
+
+bool isFormatAvailable(SceneFormat format);
+bool importScene(Scene::Document& document, const std::string& filePath, SceneFormat format, std::string* errorMessage = nullptr);
+
+}

--- a/src/FileIO/SceneIOFormat.cpp
+++ b/src/FileIO/SceneIOFormat.cpp
@@ -1,0 +1,105 @@
+#include "SceneIOFormat.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iterator>
+
+namespace FileIO {
+namespace {
+struct FormatMetadata {
+    SceneFormat format;
+    const char* displayName;
+    const char* extension;
+    bool requiresAssimp;
+    bool requiresSkp;
+};
+
+constexpr FormatMetadata kFormats[] = {
+    { SceneFormat::OBJ, "Wavefront OBJ", ".obj", false, false },
+    { SceneFormat::STL, "Stereolithography", ".stl", false, false },
+    { SceneFormat::FBX, "Autodesk FBX", ".fbx", true, false },
+    { SceneFormat::DAE, "COLLADA DAE", ".dae", true, false },
+    { SceneFormat::GLTF, "glTF 2.0", ".gltf", false, false },
+    { SceneFormat::SKP, "SketchUp (*.skp)", ".skp", false, true }
+};
+
+const FormatMetadata* lookup(SceneFormat format)
+{
+    for (const auto& meta : kFormats) {
+        if (meta.format == format) {
+            return &meta;
+        }
+    }
+    return nullptr;
+}
+}
+
+std::string formatExtension(SceneFormat format)
+{
+    const auto* meta = lookup(format);
+    return meta ? std::string(meta->extension) : std::string();
+}
+
+std::string formatDisplayName(SceneFormat format)
+{
+    const auto* meta = lookup(format);
+    return meta ? std::string(meta->displayName) : std::string();
+}
+
+std::string formatFilterString(SceneFormat format)
+{
+    const auto* meta = lookup(format);
+    if (!meta) {
+        return {};
+    }
+    std::string filter = meta->displayName;
+    filter += " (*";
+    filter += meta->extension;
+    filter += ")";
+    return filter;
+}
+
+bool formatRequiresAssimp(SceneFormat format)
+{
+    const auto* meta = lookup(format);
+    return meta ? meta->requiresAssimp : false;
+}
+
+bool formatRequiresSkp(SceneFormat format)
+{
+    const auto* meta = lookup(format);
+    return meta ? meta->requiresSkp : false;
+}
+
+std::vector<SceneFormat> allSceneFormats()
+{
+    std::vector<SceneFormat> formats;
+    formats.reserve(std::size(kFormats));
+    for (const auto& meta : kFormats) {
+        formats.push_back(meta.format);
+    }
+    return formats;
+}
+
+std::optional<SceneFormat> sceneFormatFromExtension(const std::string& extension)
+{
+    if (extension.empty()) {
+        return std::nullopt;
+    }
+    std::string normalized = extension;
+    if (normalized.front() != '.') {
+        normalized.insert(normalized.begin(), '.');
+    }
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+
+    for (const auto& meta : kFormats) {
+        if (normalized == meta.extension) {
+            return meta.format;
+        }
+    }
+    return std::nullopt;
+}
+
+}

--- a/src/FileIO/SceneIOFormat.h
+++ b/src/FileIO/SceneIOFormat.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace FileIO {
+
+enum class SceneFormat {
+    OBJ,
+    STL,
+    FBX,
+    DAE,
+    GLTF,
+    SKP
+};
+
+std::string formatExtension(SceneFormat format);
+std::string formatDisplayName(SceneFormat format);
+std::string formatFilterString(SceneFormat format);
+bool formatRequiresAssimp(SceneFormat format);
+bool formatRequiresSkp(SceneFormat format);
+std::vector<SceneFormat> allSceneFormats();
+std::optional<SceneFormat> sceneFormatFromExtension(const std::string& extension);
+
+}

--- a/src/GeometryKernel/GeometryKernel.h
+++ b/src/GeometryKernel/GeometryKernel.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <array>
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -82,6 +84,17 @@ public:
     void setAxes(const Vector3& origin, const Vector3& xDirection, const Vector3& yDirection);
     void resetAxes();
     const AxesState& getAxesState() const { return axes; }
+
+    struct MeshBuffer {
+        std::vector<Vector3> positions;
+        std::vector<Vector3> normals;
+        std::vector<std::uint32_t> indices;
+    };
+
+    MeshBuffer buildMeshBuffer(const GeometryObject& object) const;
+    static std::array<float, 16> identityTransform();
+    static HalfEdgeMesh meshFromIndexedData(const std::vector<Vector3>& positions,
+                                           const std::vector<std::uint32_t>& indices);
 
 private:
     std::vector<std::unique_ptr<GeometryObject>> objects;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4,7 +4,9 @@
 
 
 
-
+#include <QFileInfo>
+#include "FileIO/Exporters/SceneExporter.h"
+
 
 constexpr double kPi = 3.14159265358979323846;
 #include <QAction>
@@ -2546,13 +2548,92 @@ void MainWindow::createMenus()
 
     connect(actionViewFront, &QAction::triggered, this, [this]() { applyStandardView(ViewPresetManager::StandardView::Front); });
 
-
-
-
-
-
-
-    actionViewBack = viewMenu->addAction(tr("Back View"));
+void MainWindow::exportFile()
+
+
+
+{
+
+
+
+    if (!viewport) {
+        statusBar()->showMessage(tr("No active viewport to export"), 4000);
+        return;
+    }
+
+    Scene::Document* document = viewport->getDocument();
+    if (!document) {
+        statusBar()->showMessage(tr("No document attached to viewport"), 4000);
+        return;
+    }
+
+    auto formats = FileIO::Exporters::supportedFormats();
+    if (formats.empty()) {
+        QMessageBox::information(this, tr("Export Unavailable"),
+                                 tr("No export formats are enabled in this build."));
+        statusBar()->showMessage(tr("Export formats unavailable"), 4000);
+        return;
+    }
+
+    QStringList filters;
+    for (auto format : formats) {
+        filters << QString::fromStdString(FileIO::formatFilterString(format));
+    }
+
+    QFileDialog dialog(this, tr("Export Model"));
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setNameFilters(filters);
+    if (!filters.isEmpty()) {
+        dialog.selectNameFilter(filters.first());
+        const auto& defaultFormat = formats.front();
+        const std::string extension = FileIO::formatExtension(defaultFormat);
+        if (!extension.empty()) {
+            dialog.setDefaultSuffix(QString::fromStdString(extension.substr(1)));
+        }
+    }
+
+    if (dialog.exec() == QDialog::Rejected) {
+        return;
+    }
+
+    const QStringList selected = dialog.selectedFiles();
+    if (selected.isEmpty()) {
+        return;
+    }
+
+    QString filePath = selected.first();
+    QString selectedFilter = dialog.selectedNameFilter();
+    FileIO::SceneFormat chosenFormat = formats.front();
+    for (auto format : formats) {
+        if (selectedFilter == QString::fromStdString(FileIO::formatFilterString(format))) {
+            chosenFormat = format;
+            break;
+        }
+    }
+
+    QString extension = QString::fromStdString(FileIO::formatExtension(chosenFormat));
+    if (!extension.isEmpty() && !filePath.endsWith(extension, Qt::CaseInsensitive)) {
+        filePath += extension;
+    }
+
+    document->synchronizeWithGeometry();
+
+    std::string errorMessage;
+    if (!FileIO::Exporters::exportScene(*document, filePath.toStdString(), chosenFormat, &errorMessage)) {
+        QString message = QString::fromStdString(errorMessage);
+        if (message.isEmpty()) {
+            message = tr("Unknown export error");
+        }
+        QMessageBox::critical(this, tr("Export Failed"),
+                              tr("Could not export the scene:\n%1").arg(message));
+        statusBar()->showMessage(tr("Export failed"), 5000);
+        return;
+    }
+
+    statusBar()->showMessage(tr("Exported \"%1\"").arg(QFileInfo(filePath).fileName()), 4000);
+}
+
 
 
 

--- a/tests/file_io/test_exporters.cpp
+++ b/tests/file_io/test_exporters.cpp
@@ -1,0 +1,135 @@
+#include "FileIO/Exporters/SceneExporter.h"
+#include "FileIO/Importers/SceneImporter.h"
+#include "GeometryKernel/GeometryKernel.h"
+#include "GeometryKernel/Solid.h"
+#include "Scene/Document.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <filesystem>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+
+namespace {
+
+void buildSampleScene(Scene::Document& document)
+{
+    document.reset();
+    auto& kernel = document.geometry();
+    std::vector<Vector3> baseA{
+        { -0.5f, 0.0f, -0.5f },
+        { 0.5f, 0.0f, -0.5f },
+        { 0.5f, 0.0f, 0.5f },
+        { -0.5f, 0.0f, 0.5f }
+    };
+    std::vector<Vector3> baseB{
+        { 0.0f, 0.0f, -0.25f },
+        { 1.0f, 0.0f, -0.25f },
+        { 1.0f, 0.0f, 0.25f },
+        { 0.0f, 0.0f, 0.25f }
+    };
+
+    auto solidA = Solid::createFromProfile(baseA, 1.5f);
+    auto solidB = Solid::createFromProfile(baseB, 0.75f);
+    if (solidB) {
+        solidB->translate(Vector3(1.5f, 0.0f, 0.5f));
+    }
+
+    GeometryObject* objectA = kernel.addObject(std::move(solidA));
+    GeometryObject* objectB = kernel.addObject(std::move(solidB));
+
+    if (objectA) {
+        kernel.assignMaterial(objectA, "Brick");
+        document.ensureObjectForGeometry(objectA, "Block_A");
+    }
+    if (objectB) {
+        kernel.assignMaterial(objectB, "Glass");
+        document.ensureObjectForGeometry(objectB, "Block_B");
+    }
+    document.synchronizeWithGeometry();
+}
+
+struct SceneStats {
+    std::size_t triangleCount = 0;
+    std::unordered_map<std::string, std::size_t> materialTriangles;
+    Vector3 minBounds{ std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max() };
+    Vector3 maxBounds{ std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest() };
+    bool hasGeometry = false;
+};
+
+SceneStats summarizeScene(const Scene::Document& document)
+{
+    SceneStats stats;
+    const auto& objects = document.geometry().getObjects();
+    for (const auto& obj : objects) {
+        if (!obj || obj->getType() != ObjectType::Solid) {
+            continue;
+        }
+        auto buffer = document.geometry().buildMeshBuffer(*obj);
+        if (buffer.indices.empty()) {
+            continue;
+        }
+        std::size_t triangles = buffer.indices.size() / 3;
+        stats.triangleCount += triangles;
+        std::string material = document.geometry().getMaterial(obj.get());
+        stats.materialTriangles[material] += triangles;
+        for (const auto& v : buffer.positions) {
+            stats.minBounds.x = std::min(stats.minBounds.x, v.x);
+            stats.minBounds.y = std::min(stats.minBounds.y, v.y);
+            stats.minBounds.z = std::min(stats.minBounds.z, v.z);
+            stats.maxBounds.x = std::max(stats.maxBounds.x, v.x);
+            stats.maxBounds.y = std::max(stats.maxBounds.y, v.y);
+            stats.maxBounds.z = std::max(stats.maxBounds.z, v.z);
+        }
+        stats.hasGeometry = true;
+    }
+    return stats;
+}
+
+void verifyRoundTrip(FileIO::SceneFormat format, const std::filesystem::path& basePath)
+{
+    Scene::Document source;
+    buildSampleScene(source);
+    SceneStats expected = summarizeScene(source);
+    assert(expected.hasGeometry);
+
+    std::filesystem::create_directories(basePath.parent_path());
+    std::string error;
+    bool exported = FileIO::Exporters::exportScene(source, basePath.string(), format, &error);
+    assert(exported);
+    assert(error.empty());
+
+    Scene::Document imported;
+    std::string importError;
+    bool importedOk = FileIO::Importers::importScene(imported, basePath.string(), format, &importError);
+    assert(importedOk);
+    assert(importError.empty());
+
+    SceneStats actual = summarizeScene(imported);
+    assert(actual.hasGeometry);
+    assert(actual.triangleCount == expected.triangleCount);
+    assert(actual.materialTriangles == expected.materialTriangles);
+    const float tolerance = 1e-3f;
+    auto within = [&](float a, float b) {
+        return std::abs(a - b) <= tolerance;
+    };
+    assert(within(actual.minBounds.x, expected.minBounds.x));
+    assert(within(actual.minBounds.y, expected.minBounds.y));
+    assert(within(actual.minBounds.z, expected.minBounds.z));
+    assert(within(actual.maxBounds.x, expected.maxBounds.x));
+    assert(within(actual.maxBounds.y, expected.maxBounds.y));
+    assert(within(actual.maxBounds.z, expected.maxBounds.z));
+}
+
+}
+
+int main()
+{
+    const auto tempRoot = std::filesystem::temp_directory_path() / "freecrafter_file_io_tests";
+    verifyRoundTrip(FileIO::SceneFormat::OBJ, tempRoot / "scene.obj");
+    verifyRoundTrip(FileIO::SceneFormat::STL, tempRoot / "scene.stl");
+    verifyRoundTrip(FileIO::SceneFormat::GLTF, tempRoot / "scene.gltf");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add reusable scene I/O descriptors, Assimp/tinygltf friendly exporters, and simple importer fallbacks
- extend the geometry kernel with mesh-buffer utilities so exporters can harvest indexed triangles and transforms without touching .fcm serialization
- hook the MainWindow export workflow into the new layer, document third-party licensing expectations, and add regression tests for OBJ/STL/glTF round-trips

## Testing
- cmake -S . -B build *(fails: Qt6 toolchain not present in container)*