### PR TITLE
Fix rectangle and circle tool activation names

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2596,13 +2596,13 @@ void MainWindow::activateLine()
 
 void MainWindow::activateRectangle()
 {
-    setActiveTool(rectangleAction, QStringLiteral("RectangleTool"),
+    setActiveTool(rectangleAction, QStringLiteral("Rectangle"),
         tr("Rectangle: Click the first corner, then click the opposite corner to finish."));
 }
 
 void MainWindow::activateCircle()
 {
-    setActiveTool(circleAction, QStringLiteral("CircleTool"),
+    setActiveTool(circleAction, QStringLiteral("Circle"),
         tr("Circle: Click to set the center, then click again to define the radius."));
 }
 


### PR DESCRIPTION
## Summary
- activate the rectangle ribbon action using the existing "Rectangle" tool id
- activate the circle ribbon action using the existing "Circle" tool id

## Testing
- not run (Qt6 SDK not available in container)